### PR TITLE
Exercise 25 -- SINR calculation options, SINR bar graph, Dev/Advanced mode feature, some bug fixes

### DIFF
--- a/01_bw.html
+++ b/01_bw.html
@@ -16,7 +16,7 @@
 
 
 <body style="margin:0;">
-  <!-- <h2>Exercise 1 - Bandwidth</h2>
+  <!-- <h2>Bandwidth (Time- and Frequency-Domain)</h2>
   <p><a href="index.html">[exercises]</a></p> -->
 
 

--- a/01_bw.html
+++ b/01_bw.html
@@ -16,7 +16,7 @@
 
 
 <body style="margin:0;">
-  <!-- <h2>Bandwidth (Time- and Frequency-Domain)</h2>
+  <!-- <h2>Exercise 1 - Bandwidth</h2>
   <p><a href="index.html">[exercises]</a></p> -->
 
 
@@ -62,7 +62,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 1</span> Bandwidth</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 1</span> Bandwidth (in time and frequency domains)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/02_freq.html
+++ b/02_freq.html
@@ -61,7 +61,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 2</span> Frequency</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 2</span> Frequency (in time and frequency domains)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/03_gn.html
+++ b/03_gn.html
@@ -60,7 +60,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 3</span> Gain</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 3</span> Gain (in time and frequency domains)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/04_freq_bw_gn.html
+++ b/04_freq_bw_gn.html
@@ -60,7 +60,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 4</span> Frequency, Bandwidth, and Gain</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 4</span> Frequency, Bandwidth, and Gain (in time and frequency domains)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/05_capacity.html
+++ b/05_capacity.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+<!-- 
+To Do: Replace text-based status display with bar graph that includes text labels 
+and numeric values 
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 5</title>
@@ -61,7 +65,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 5</span> Information Capacity (To Do: Replace text-based status display with bar graph that includes text labels and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 5</span> Information Capacity</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/05_capacity.html
+++ b/05_capacity.html
@@ -61,7 +61,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 5</span> Information Capacity (To Do: Replace SNR and Information Capacity text display with bar graph that includes text labels and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 5</span> Information Capacity (To Do: Replace text-based status display with bar graph that includes text labels and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/05_capacity.html
+++ b/05_capacity.html
@@ -61,7 +61,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 5</span> Information Capacity</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 5</span> Information Capacity (To Do: Replace SNR and Information Capacity text display with bar graph that includes text labels and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/06_interference.html
+++ b/06_interference.html
@@ -61,7 +61,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 6</span> Interference and Information Capacity (To Do: Replace SINR and Information Capacity text display with bar graph that includes text labels and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 6</span> Interference and Information Capacity (To Do: Replace text-based status display with bar graph that includes text labels and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/06_interference.html
+++ b/06_interference.html
@@ -61,7 +61,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 6</span> Interference and Information Capacity</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 6</span> Interference and Information Capacity (To Do: Replace SINR and Information Capacity text display with bar graph that includes text labels and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/06_interference.html
+++ b/06_interference.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+<!-- 
+To Do: Replace text-based status display with bar graph that includes text labels 
+and numeric values 
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 6</title>
@@ -61,7 +65,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 6</span> Interference and Information Capacity (To Do: Replace text-based status display with bar graph that includes text labels and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 6</span> Interference and Information Capacity</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/07_capacity.html
+++ b/07_capacity.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 7</span> Information Capacity</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 7</span> Information Capacity and Spectral Efficiency (To Do: Replace SNR, Information Capacity, and Spectral Efficiency text display with bar graph that includes text labels and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/07_capacity.html
+++ b/07_capacity.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 7</span> Information Capacity and Spectral Efficiency (To Do: Replace SNR, Information Capacity, and Spectral Efficiency text display with bar graph that includes text labels and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 7</span> Information Capacity and Spectral Efficiency (To Do: Replace text-based status display with bar graph that includes text labels and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/07_capacity.html
+++ b/07_capacity.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+<!-- 
+To Do: Replace text-based status display with bar graph that includes text labels 
+and numeric values 
+-->
 <html lang="en-US" style="display: flex;">
 <head>
   <title>HLSI Ex 7</title>
@@ -54,7 +58,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 7</span> Information Capacity and Spectral Efficiency (To Do: Replace text-based status display with bar graph that includes text labels and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 7</span> Information Capacity and Spectral Efficiency</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/08_capacity.html
+++ b/08_capacity.html
@@ -66,7 +66,7 @@
     
   </aside>
   
-  <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 8</span> Information Capacity, Achievable Data Rate using Selected Modulation and Error Correction Coding Scheme (MCS), and Spectral Efficiency (To Do: Replace SNR and Information Capacity text display with bar graph that includes text labels and numeric values)</div>
+  <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 8</span> Information Capacity, Achievable Data Rate using Selected Modulation and Error Correction Coding Scheme (MCS), and Spectral Efficiency (To Do: Replace text-based status display with bar graph that includes text labels and numeric values)</div>
   <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
     <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
     <div style="width: 20%;">

--- a/08_capacity.html
+++ b/08_capacity.html
@@ -66,7 +66,7 @@
     
   </aside>
   
-  <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 8</span> Information Capacity</div>
+  <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 8</span> Information Capacity, Achievable Data Rate using Selected Modulation and Error Correction Coding Scheme (MCS), and Spectral Efficiency (To Do: Replace SNR and Information Capacity text display with bar graph that includes text labels and numeric values)</div>
   <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
     <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
     <div style="width: 20%;">

--- a/08_capacity.html
+++ b/08_capacity.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+<!-- 
+To Do: Replace text-based status display with bar graph that includes text labels 
+and numeric values 
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 8</title>
@@ -66,7 +70,7 @@
     
   </aside>
   
-  <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 8</span> Information Capacity, Achievable Data Rate using Selected Modulation and Error Correction Coding Scheme (MCS), and Spectral Efficiency (To Do: Replace text-based status display with bar graph that includes text labels and numeric values)</div>
+  <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 8</span> Information Capacity, Achievable Data Rate using Selected Modulation and Error Correction Coding Scheme (MCS), and Spectral Efficiency</div>
   <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
     <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
     <div style="width: 20%;">

--- a/09_capacity.html
+++ b/09_capacity.html
@@ -69,7 +69,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 9</span> Timed Simulation of Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel, with Manual MCS Adaptation (To Do: Add Data Rate History plot; Replace text display with bar graph that includes text labels, numeric values, and average or cumulative metrics for the ongoing or most recent simulation interval)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 9</span> Timed Simulation of Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel, with Manual MCS Adaptation (To Do: Add Data Rate History plot; Replace text-based status display with bar graph that includes text labels, numeric values, and average or cumulative metrics for the ongoing or most recent simulation interval)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/09_capacity.html
+++ b/09_capacity.html
@@ -69,7 +69,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 9</span> Information Capacity</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 9</span> Timed Simulation of Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel, with Manual MCS Adaptation (To Do: Add Data Rate History plot; Replace text display with bar graph that includes text labels, numeric values, and average or cumulative metrics for the ongoing or most recent simulation interval)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/09_capacity.html
+++ b/09_capacity.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!-- 
+To Do: Add Data Rate History plot; Replace text-based status display with bar graph 
+that includes text labels, numeric values, and average or cumulative metrics for 
+the ongoing or most recent simulation interval 
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 9</title>
@@ -69,7 +74,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 9</span> Timed Simulation of Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel, with Manual MCS Adaptation (To Do: Add Data Rate History plot; Replace text-based status display with bar graph that includes text labels, numeric values, and average or cumulative metrics for the ongoing or most recent simulation interval)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 9</span> Timed Simulation of Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel, with Manual MCS Adaptation</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/10_capacity.html
+++ b/10_capacity.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 10</span> Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel with Programmable Automatic MCS Adaptation (To Do: Replace text display with bar graph that includes text labels, numeric values, and average or cumulative metrics for the ongoing or most recent simulation interval)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 10</span> Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel with Programmable Automatic MCS Adaptation (To Do: Replace text-based status display with bar graph that includes text labels, numeric values, and average or cumulative metrics for the ongoing or most recent simulation interval)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/10_capacity.html
+++ b/10_capacity.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!-- 
+To Do: Replace text-based status display with bar graph that includes text labels, 
+numeric values, and average or cumulative metrics for the ongoing or most recent 
+simulation interval 
+-->
 <html lang="en-US" style="display: flex;">
 <head>
   <title>HLSI Ex 10</title>
@@ -54,7 +59,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 10</span> Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel with Programmable Automatic MCS Adaptation (To Do: Replace text-based status display with bar graph that includes text labels, numeric values, and average or cumulative metrics for the ongoing or most recent simulation interval)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 10</span> Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel with Programmable Automatic MCS Adaptation</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/10_capacity.html
+++ b/10_capacity.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 10</span> Information Capacity</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 10</span> Information Capacity, Data Rate, and Spectral Efficiency in Fading Channel with Programmable Automatic MCS Adaptation (To Do: Replace text display with bar graph that includes text labels, numeric values, and average or cumulative metrics for the ongoing or most recent simulation interval)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/11_pathloss.html
+++ b/11_pathloss.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 11</span> Path Loss</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 11</span> Path Loss (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text display with bar graph that includes text labels, and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/11_pathloss.html
+++ b/11_pathloss.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 11</span> Path Loss (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text display with bar graph that includes text labels, and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 11</span> Path Loss (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text-based status display with bar graph that includes text labels, and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/11_pathloss.html
+++ b/11_pathloss.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!-- 
+To Do: Update spectrum plot to use Lance's framework; Add path loss model menu 
+with 2-3 models; Replace text-based status display with bar graph that includes 
+text labels, and numeric values 
+-->
 <html lang="en-US" style="display: flex;">
 <head>
   <title>11 - Path Loss</title>
@@ -54,7 +59,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 11</span> Path Loss (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text-based status display with bar graph that includes text labels, and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 11</span> Path Loss </div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/12_pathloss_interference.html
+++ b/12_pathloss_interference.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 12</span> Path Loss with Interference</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 12</span> Path Loss with Interference (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text display with bar graph that includes text labels, and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/12_pathloss_interference.html
+++ b/12_pathloss_interference.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 12</span> Path Loss with Interference (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text display with bar graph that includes text labels, and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 12</span> Path Loss with Interference (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text-based status display with bar graph that includes text labels, and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/12_pathloss_interference.html
+++ b/12_pathloss_interference.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!-- 
+To Do: Update spectrum plot to use Lance's framework; Add path loss model menu 
+with 2-3 models; Replace text-based status display with bar graph that includes 
+text labels, and numeric values
+-->
 <html lang="en-US" style="display: flex;">
 <head>
   <title>12 - Path Loss</title>
@@ -54,7 +59,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 12</span> Path Loss with Interference (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text-based status display with bar graph that includes text labels, and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 12</span> Path Loss with Interference</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/13_manual_avoidance.html
+++ b/13_manual_avoidance.html
@@ -70,7 +70,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 13</span> Manual Interferer Avoidance</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 13</span> Manual Interferer Avoidance (To Do:  Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/13_manual_avoidance.html
+++ b/13_manual_avoidance.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!-- 
+To Do:  Add timer with Start/Reset button(s); Replace text-based status display with 
+bar graph including average/cumulative statistics for current or most recent timed 
+simulation that freezes at end of timed simulation 
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 13</title>
@@ -70,7 +75,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 13</span> Manual Interferer Avoidance (To Do:  Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 13</span> Manual Interferer Avoidance</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/15_rule_based_avoidance.html
+++ b/15_rule_based_avoidance.html
@@ -72,7 +72,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 15</span> Rule Based Interferer Avoidance</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 15</span> Rule Based Interferer Avoidance (To Do:  Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/15_rule_based_avoidance.html
+++ b/15_rule_based_avoidance.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+To Do:  Add timer with Start/Reset button(s); Replace text-based status display 
+with bar graph including average/cumulative statistics for current or most recent 
+timed simulation that freezes at end of timed simulation
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 15</title>
@@ -72,7 +77,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 15</span> Rule Based Interferer Avoidance (To Do:  Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 15</span> Rule Based Interferer Avoidance </div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/16_programmable_avoidance.html
+++ b/16_programmable_avoidance.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
+<!-- 
+To Do:  Update callback functions and remove redundant or minimally effective options 
+from callback function menu; Add timer with Start/Reset button(s); Replace text-based 
+status display with bar graph including average/cumulative statistics for current or most 
+recent timed simulation that freezes at end of timed simulation)
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 16</title>
@@ -74,7 +80,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 16</span> Programmable Interferer Avoidance (To Do:  Update callback functions and remove redundant or minimally effective options from callback function menu; Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 16</span> Programmable Interferer Avoidance</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/16_programmable_avoidance.html
+++ b/16_programmable_avoidance.html
@@ -74,7 +74,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 16</span> Programmable Interferer Avoidance</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 16</span> Programmable Interferer Avoidance (To Do:  Update callback functions and remove redundant or minimally effective options from callback function menu; Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/17_machine_learning_avoidance.html
+++ b/17_machine_learning_avoidance.html
@@ -77,7 +77,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 17</span> Machine Learning Interferer Avoidance</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 17</span> Machine Learning Interferer Avoidance (To Do:  Update callback functions and remove redundant or minimally effective options from callback function menu; Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/17_machine_learning_avoidance.html
+++ b/17_machine_learning_avoidance.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+To Do:  Update callback functions and remove redundant or minimally effective 
+options from callback function menu; Add timer with Start/Reset button(s); 
+Replace text-based status display with bar graph including average/cumulative 
+statistics for current or most recent timed simulation that freezes at end of 
+timed simulation
+ -->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 17</title>
@@ -77,7 +84,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 17</span> Machine Learning Interferer Avoidance (To Do:  Update callback functions and remove redundant or minimally effective options from callback function menu; Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 17</span> Machine Learning Interferer Avoidance</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/18_machine_learning_time_based_avoidance.html
+++ b/18_machine_learning_time_based_avoidance.html
@@ -76,7 +76,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 18</span> Machine Learning With Periodic Interferer Avoidance</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 18</span> Machine Learning With Periodic Interferer Avoidance (To Do:  Update callback functions and remove redundant or minimally effective options from callback function menu; Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/18_machine_learning_time_based_avoidance.html
+++ b/18_machine_learning_time_based_avoidance.html
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
-<html lang="en-US" style="display: flex;">
+<!--
+To Do:  Update callback functions and remove redundant or minimally effective 
+options from callback function menu; Add timer with Start/Reset button(s); 
+Replace text-based status display with bar graph including average/cumulative 
+statistics for current or most recent timed simulation that freezes at end of 
+timed simulation
+ -->
+ <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 18</title>
     <meta charset="UTF-8"/>
@@ -63,7 +70,7 @@
         <a href="15_rule_based_avoidance.html"><b>15</b> Rule Based Interferer Avoidance</a>
         <a href="16_programmable_avoidance.html"><b>16</b> Programmable Interferer Avoidance</a>
         <a href="17_machine_learning_avoidance.html"><b>17</b> Machine Learning Interferer Avoidance</a>
-        <a href="18_machine_learning_time_based_avoidance.html" class="selected"><b>18</b> Machine Learning With Periodic Interferer Avoidance</a>
+        <a href="18_machine_learning_time_based_avoidance.html" class="selected"><b>18</b> Machine Learning Interference Avoidance with Periodic or Randomly-Hopping Interferer</a>
         <a href="19_rf_front_end_spectrum_sharing.html"><b>19</b> RF Front End Spectrum Sharing</a>
         <a href="20_rf_front_end_spectrum_sharing.html"><b>20</b> Programmable RF Front End Spectrum Sharing</a>
         <a href="21_rf_front_end_spectrum_sharing_with_interferer.html"><b>21</b> RF Front End Spectrum Sharing with Interferer</a>
@@ -76,7 +83,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 18</span> Machine Learning With Periodic Interferer Avoidance (To Do:  Update callback functions and remove redundant or minimally effective options from callback function menu; Add timer with Start/Reset button(s); Replace text-based status display with bar graph including average/cumulative statistics for current or most recent timed simulation that freezes at end of timed simulation)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 18</span> Machine Learning Interference Avoidance with Periodic or Randomly-Hopping Interferer</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/19_rf_front_end_spectrum_sharing.html
+++ b/19_rf_front_end_spectrum_sharing.html
@@ -24,6 +24,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
     <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
     <script src=spectralEfficiencyPlot_BarChart.js></script>
+    <script src=sinrPlot_BarChart.js></script>
     <script src=label.js></script>
     <script src=capacityBanner.js></script>
     <!-- <script src=throughputPlot.js></script> -->
@@ -204,17 +205,20 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     </div>
   </div>
 
-  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%;"></div>
+  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%; margin-top: 1.5%;"></div>
 
-  <div style="width: 720px; height: 320px; display: inline-block;">
-      <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+
+  <div style="display: inline-block; margin-left: 1%;" id="throughput-multisignal">
+    <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
   </div>
-  
-  <div style="margin-left:2%;">
-    <div style="display: inline-flex;">
-      <div style="width: 28px; height: 3px; background:rgba(255,255,255,255); margin-top: 8px; margin-right: 5px;"></div>
-      <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
-    </div>
+
+<div style="display: inline-flex;">
+  <div style="width: 720px; height: 320px; margin-top: 1%;">
+    <canvas id="sinr-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+  </div>
+
+  <div style="width: 720px; height: 320px; margin-top: 1%; float: right; margin-left: 1%;">
+    <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
   </div>
 </body>
 <script>
@@ -313,14 +317,16 @@ Slider(sig4, 'mcs', '#mcs4');
 // HoppingInterferer(interferer, '#hoppingInterferer');
 CapacityBanner(sig1, '#capacityBanner');
 
-PowerSpectrumPlot_2D();
-ThroughputPlot([sig1, sig2, sig3, sig4]);
+  ThroughputPlot([sig1, sig2, sig3, sig4]);
+  PowerSpectrumPlot_2D();
 
-// document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
-//       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
-//   </div>`
+  // document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
+  //       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
+  //   </div>`
 
+  SinrPlot_BarChart.init([sig1, sig2, sig3, sig4], "sinr-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4"]);
 
-SpectralEfficiencyPlot_BarChart.init([sig1, sig2, sig3, sig4], "spectral-efficiency-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4", "Average Total"]);
+  SpectralEfficiencyPlot_BarChart.init([sig1, sig2, sig3, sig4], "spectral-efficiency-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4", "Average Total"]);
+
 </script>
 </html>

--- a/19_rf_front_end_spectrum_sharing.html
+++ b/19_rf_front_end_spectrum_sharing.html
@@ -102,8 +102,8 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
 
     <p><label for="mode">Select mode:</label> &nbsp;
       <select id="mode" onchange="onModeChange()">
-        <option value="m0">Beginner</option>
-        <option value="m1">Advanced</option>
+        <option id="beginner" value="beginner">Beginner</option>
+        <option id="advanced" value="advanced">Advanced</option>
       </select>
     </p>
 
@@ -219,6 +219,19 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
 </body>
 <script>
 'use strict';
+
+// function to listen to url changes
+  window.onload = function () {
+    const urlParams = new URLSearchParams(location.search);
+
+    for (const [key, value] of urlParams) {
+      let val = value.toLowerCase();
+      if (key == 'mode' && ['beginner', 'advanced'].includes(val)) {
+        document.getElementById(val).selected = "selected";
+        onModeChange();
+      }
+    }
+  };
 
 
 var sig1 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {

--- a/19_rf_front_end_spectrum_sharing.html
+++ b/19_rf_front_end_spectrum_sharing.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+To Do: Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options 
+for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; 
+Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 19</title>
@@ -78,7 +83,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 19</span> RF Front End - Spectrum Sharing (To Do: Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 19</span> Spectrum Sharing -- Manual</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/19_rf_front_end_spectrum_sharing.html
+++ b/19_rf_front_end_spectrum_sharing.html
@@ -19,6 +19,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     <script src=signal.js></script>
     <!-- <script src=sliders.js></script> -->
     <script src=slidersMultiSignals.js></script>
+    <script src=modeController.js></script>
     <!-- <script src=powerSpectrumPlot.js></script> -->
     <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
     <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
@@ -92,11 +93,18 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     </div>   
   </section>
   
-  <div class="content-section" style="margin: 0% 2%; margin-top: 8%;">
+  <div class="content-section" style="margin: 0% 2%; margin-top: 6%;">
     <!-- <p id=hoppingInterferer>
     </p> -->
   
     <p id=capacityBanner style="display: none;">
+    </p>
+
+    <p><label for="mode">Select mode:</label> &nbsp;
+      <select id="mode" onchange="onModeChange()">
+        <option value="m0">Beginner</option>
+        <option value="m1">Advanced</option>
+      </select>
     </p>
 
     <div style="display: inline-flex; width: 100%;">
@@ -106,13 +114,13 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
           <input type="range" id=freq1 />
         </p>
         <p>
-          <input type="range" id=bw1 />
+          <input type="range" id=bw1 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn1 />
+          <input type="range" id=gn1 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs1 />
+          <input type="range" id=mcs1 style="display: none;" />
         </p>
       </div>
 
@@ -122,13 +130,13 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
           <input type="range" id=freq2 />
         </p>
         <p>
-          <input type="range" id=bw2 />
+          <input type="range" id=bw2 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn2 />
+          <input type="range" id=gn2 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs2 />
+          <input type="range" id=mcs2 style="display: none;" />
         </p>
       </div>
 
@@ -138,13 +146,13 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
           <input type="range" id=freq3 />
         </p>
         <p>
-          <input type="range" id=bw3 />
+          <input type="range" id=bw3 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn3 />
+          <input type="range" id=gn3 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs3 />
+          <input type="range" id=mcs3 style="display: none;" />
         </p>
       </div>
 
@@ -154,13 +162,13 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
           <input type="range" id=freq4 />
         </p>
         <p>
-          <input type="range" id=bw4 />
+          <input type="range" id=bw4 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn4 />
+          <input type="range" id=gn4 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs4 />
+          <input type="range" id=mcs4 style="display: none;" />
         </p>
       </div>
     </div>
@@ -267,7 +275,7 @@ var sig4 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {
 // });
 
 
-// var noise = Signal(conf.noise, "Noise", { gn_init: -40})
+var noise = Signal(conf.noise, "Noise", { gn_init: -40})
 
 Slider(sig1, 'freq', '#freq1');
 Slider(sig1, 'bw', '#bw1');

--- a/19_rf_front_end_spectrum_sharing.html
+++ b/19_rf_front_end_spectrum_sharing.html
@@ -78,7 +78,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 19</span> RF Front End - Spectrum Sharing</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 19</span> RF Front End - Spectrum Sharing (To Do: Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/20_rf_front_end_spectrum_sharing.html
+++ b/20_rf_front_end_spectrum_sharing.html
@@ -90,7 +90,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 20</span> RF Front End - Spectrum Sharing - Automatic Frequency Assignment</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 20</span> RF Front End - Spectrum Sharing - Automatic Frequency Assignment (To Do: Add timer, Start/Reset button, and average cumulative statistics; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/20_rf_front_end_spectrum_sharing.html
+++ b/20_rf_front_end_spectrum_sharing.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
-<html lang="en-US" style="display: flex;">
+<!--
+To Do: Add timer, Start/Reset button, and average cumulative statistics; Add Guard Bands w/ flashing 
+"too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum 
+for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-
+dependent ACI-based SINR
+ -->
+ <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 20</title>
     <meta charset="UTF-8"/>
@@ -90,7 +96,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 20</span> RF Front End - Spectrum Sharing - Automatic Frequency Assignment (To Do: Add timer, Start/Reset button, and average cumulative statistics; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 20</span> Spectrum Sharing -- Automatic</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/20_rf_front_end_spectrum_sharing.html
+++ b/20_rf_front_end_spectrum_sharing.html
@@ -33,6 +33,7 @@ dependent ACI-based SINR
     <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
     <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
     <script src=spectralEfficiencyPlot_BarChart.js></script>
+    <script src=sinrPlot_BarChart.js></script>
     <script src=label.js></script>
     <script src=capacityBanner.js></script>
     <!-- <script src=throughputPlot.js></script> -->
@@ -143,10 +144,20 @@ dependent ACI-based SINR
     </div>
   </div>
 
-  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%;"></div>
+  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%; margin-top: 1.5%;"></div>
 
-  <div style="width: 720px; height: 320px; display: inline-block;">
-      <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+
+  <div style="display: inline-block; margin-left: 1%;" id="throughput-multisignal">
+    <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
+  </div>
+
+<div style="display: inline-flex;">
+  <div style="width: 720px; height: 320px; margin-top: 1%;">
+    <canvas id="sinr-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+  </div>
+
+  <div style="width: 720px; height: 320px; margin-top: 1%; float: right; margin-left: 1%;">
+    <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
   </div>
   
   
@@ -239,14 +250,16 @@ new ScriptController([ sig1, sig2, sig3, sig4 ], {
 // HoppingInterferer(interferer, '#hoppingInterferer');
 CapacityBanner(sig1, '#capacityBanner');
 
-PowerSpectrumPlot_2D();
 ThroughputPlot([sig1, sig2, sig3, sig4]);
+PowerSpectrumPlot_2D();
 
-// document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
-//       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
-//   </div>`
+  // document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
+  //       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
+  //   </div>`
 
+SinrPlot_BarChart.init([sig1, sig2, sig3, sig4], "sinr-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4"]);
 
 SpectralEfficiencyPlot_BarChart.init([sig1, sig2, sig3, sig4], "spectral-efficiency-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4", "Average Total"]);
+
 </script>
 </html>

--- a/20_rf_front_end_spectrum_sharing.html
+++ b/20_rf_front_end_spectrum_sharing.html
@@ -209,7 +209,7 @@ var sig4 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {
 // });
 
 
-// var noise = Signal(conf.noise, "Noise", { gn_init: -40})
+var noise = Signal(conf.noise, "Noise", { gn_init: -40})
 
 new ScriptController([ sig1, sig2, sig3, sig4 ], { 
     element: '#scriptController',

--- a/21_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/21_rf_front_end_spectrum_sharing_with_interferer.html
@@ -24,6 +24,7 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
     <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
     <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
     <script src=spectralEfficiencyPlot_BarChart.js></script>
+    <script src=sinrPlot_BarChart.js></script>
     <script src=label.js></script>
     <script src=capacityBanner.js></script>
     <!-- <script src=throughputPlot.js></script> -->
@@ -224,18 +225,21 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
     </div>
   </div>
 
-  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%;"></div>
+  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%; margin-top: 1.5%;"></div>
 
-  <div style="width: 720px; height: 320px; display: inline-block;">
-      <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+
+  <div style="display: inline-block; margin-left: 1%;" id="throughput-multisignal">
+    <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
   </div>
-  
-  <div style="margin-left:2%;">
-    <div style="display: inline-flex;">
-      <div style="width: 28px; height: 3px; background:rgba(255,255,255,255); margin-top: 8px; margin-right: 5px;"></div>
-      <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
-    </div>
+
+<div style="display: inline-flex;">
+  <div style="width: 720px; height: 320px; margin-top: 1%;">
+    <canvas id="sinr-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
   </div>
+
+  <div style="width: 720px; height: 320px; margin-top: 1%; float: right; margin-left: 1%;">
+    <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+</div>
 </body>
 <script>
 'use strict';
@@ -341,13 +345,14 @@ Slider(sig4, 'mcs', '#mcs4');
 HoppingInterferer(interferer, '#hoppingInterferer');
 CapacityBanner(sig1, '#capacityBanner');
 
-PowerSpectrumPlot_2D();
 ThroughputPlot([sig1, sig2, sig3, sig4]);
+PowerSpectrumPlot_2D();
 
-// document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
-//       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
-//   </div>`
+  // document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
+  //       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
+  //   </div>`
 
+SinrPlot_BarChart.init([sig1, sig2, sig3, sig4], "sinr-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4"]);
 
 SpectralEfficiencyPlot_BarChart.init([sig1, sig2, sig3, sig4], "spectral-efficiency-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4", "Average Total"]);
 

--- a/21_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/21_rf_front_end_spectrum_sharing_with_interferer.html
@@ -78,7 +78,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 21</span> RF Front End - Spectrum Sharing with Interferer</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 21</span> RF Front End - Spectrum Sharing with Interferer (To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/21_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/21_rf_front_end_spectrum_sharing_with_interferer.html
@@ -122,8 +122,8 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
 
     <p><label for="mode">Select mode:</label> &nbsp;
       <select id="mode" onchange="onModeChange()">
-        <option value="m0">Beginner</option>
-        <option value="m1">Advanced</option>
+        <option id="beginner" value="beginner">Beginner</option>
+        <option id="advanced" value="advanced">Advanced</option>
       </select>
     </p>
 
@@ -239,6 +239,19 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
 </body>
 <script>
 'use strict';
+
+// function to listen to url changes
+window.onload = function () {
+    const urlParams = new URLSearchParams(location.search);
+
+    for (const [key, value] of urlParams) {
+      let val = value.toLowerCase();
+      if (key == 'mode' && ['beginner', 'advanced'].includes(val)) {
+        document.getElementById(val).selected = "selected";
+        onModeChange();
+      }
+    }
+};
 
 var interferer = new Signal(conf.sig0, 'interferer', {
     bw_max: 38.0e6, // Hz

--- a/21_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/21_rf_front_end_spectrum_sharing_with_interferer.html
@@ -19,6 +19,7 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
     <script src=signal.js></script>
     <!-- <script src=sliders.js></script> -->
     <script src=slidersMultiSignals.js></script>
+    <script src=modeController.js></script>
     <!-- <script src=powerSpectrumPlot.js></script> -->
     <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
     <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
@@ -119,6 +120,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
     <p id=capacityBanner style="display: none;">
     </p>
 
+    <p><label for="mode">Select mode:</label> &nbsp;
+      <select id="mode" onchange="onModeChange()">
+        <option value="m0">Beginner</option>
+        <option value="m1">Advanced</option>
+      </select>
+    </p>
+
     <div style="display: inline-flex; width: 100%;">
       <div style="width: 25%;">
         <div style="font-size: 110%; color: #ff6b6b">Comm Link 1</div>
@@ -126,13 +134,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
           <input type="range" id=freq1 />
         </p>
         <p>
-          <input type="range" id=bw1 />
+          <input type="range" id=bw1 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn1 />
+          <input type="range" id=gn1 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs1 />
+          <input type="range" id=mcs1 style="display: none;" />
         </p>
       </div>
 
@@ -142,13 +150,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
           <input type="range" id=freq2 />
         </p>
         <p>
-          <input type="range" id=bw2 />
+          <input type="range" id=bw2 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn2 />
+          <input type="range" id=gn2 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs2 />
+          <input type="range" id=mcs2 style="display: none;" />
         </p>
       </div>
 
@@ -158,13 +166,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
           <input type="range" id=freq3 />
         </p>
         <p>
-          <input type="range" id=bw3 />
+          <input type="range" id=bw3 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn3 />
+          <input type="range" id=gn3 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs3 />
+          <input type="range" id=mcs3 style="display: none;" />
         </p>
       </div>
 
@@ -174,13 +182,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
           <input type="range" id=freq4 />
         </p>
         <p>
-          <input type="range" id=bw4 />
+          <input type="range" id=bw4 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn4 />
+          <input type="range" id=gn4 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs4 />
+          <input type="range" id=mcs4 style="display: none;" />
         </p>
       </div>
     </div>
@@ -295,7 +303,7 @@ var sig4 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {
 // });
 
 
-// var noise = Signal(conf.noise, "Noise", { gn_init: -40})
+var noise = Signal(conf.noise, "Noise", { gn_init: -40})
 
 Slider(sig1, 'freq', '#freq1');
 Slider(sig1, 'bw', '#bw1');

--- a/21_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/21_rf_front_end_spectrum_sharing_with_interferer.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu 
+with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for 
+Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR
+-->
 <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 21</title>
@@ -78,7 +83,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 21</span> RF Front End - Spectrum Sharing with Interferer (To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 21</span> Spectrum Sharing with Interferer -- Manual</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/22_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/22_rf_front_end_spectrum_sharing_with_interferer.html
@@ -239,7 +239,7 @@ var sig4 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {
 // });
 
 
-// var noise = Signal(conf.noise, "Noise", { gn_init: -40})
+var noise = Signal(conf.noise, "Noise", { gn_init: -40})
 
 new ScriptController([ sig1, sig2, sig3, sig4 ], { 
     element: '#scriptController',

--- a/22_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/22_rf_front_end_spectrum_sharing_with_interferer.html
@@ -90,7 +90,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 22</span> RF Front End - Spectrum Sharing - Automatic Frequency Assignment</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 22</span> RF Front End - Spectrum Sharing - Automatic Frequency Assignment (To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/22_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/22_rf_front_end_spectrum_sharing_with_interferer.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
-<html lang="en-US" style="display: flex;">
+<!--
+To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, 
+Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for 
+Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o 
+ACI vs. receiver-dependent ACI-based SINR
+ -->
+ <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 22</title>
     <meta charset="UTF-8"/>
@@ -90,7 +96,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 22</span> RF Front End - Spectrum Sharing - Automatic Frequency Assignment (To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 22</span> Spectrum Sharing -- Automatic with Programmable Interferer</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/22_rf_front_end_spectrum_sharing_with_interferer.html
+++ b/22_rf_front_end_spectrum_sharing_with_interferer.html
@@ -33,6 +33,7 @@ ACI vs. receiver-dependent ACI-based SINR
     <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
     <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
     <script src=spectralEfficiencyPlot_BarChart.js></script>
+    <script src=sinrPlot_BarChart.js></script>
     <script src=label.js></script>
     <script src=capacityBanner.js></script>
     <!-- <script src=throughputPlot.js></script> -->
@@ -166,11 +167,21 @@ ACI vs. receiver-dependent ACI-based SINR
     </div>
   </div>
 
-  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%;"></div>
+  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%; margin-top: 1.5%;"></div>
 
-  <div style="width: 720px; height: 320px; display: inline-block;">
-      <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+
+  <div style="display: inline-block; margin-left: 1%;" id="throughput-multisignal">
+    <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
   </div>
+
+<div style="display: inline-flex;">
+  <div style="width: 720px; height: 320px; margin-top: 1%;">
+    <canvas id="sinr-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+  </div>
+
+  <div style="width: 720px; height: 320px; margin-top: 1%; float: right; margin-left: 1%;">
+    <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+</div>
   
   
 </body>
@@ -269,13 +280,14 @@ new ScriptController([ sig1, sig2, sig3, sig4 ], {
 HoppingInterferer(interferer, '#hoppingInterferer');
 CapacityBanner(sig1, '#capacityBanner');
 
-PowerSpectrumPlot_2D();
 ThroughputPlot([sig1, sig2, sig3, sig4]);
+PowerSpectrumPlot_2D();
 
-// document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
-//       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
-//   </div>`
+  // document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
+  //       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
+  //   </div>`
 
+SinrPlot_BarChart.init([sig1, sig2, sig3, sig4], "sinr-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4"]);
 
 SpectralEfficiencyPlot_BarChart.init([sig1, sig2, sig3, sig4], "spectral-efficiency-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4", "Average Total"]);
 

--- a/23_rf_front_end_spectrum_sharing_sliders_programmable.html
+++ b/23_rf_front_end_spectrum_sharing_sliders_programmable.html
@@ -28,6 +28,7 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
     <script src=signal.js></script>
     <!-- <script src=sliders.js></script> -->
     <script src=slidersMultiSignals.js></script>
+    <script src=modeController.js></script>
     <!-- <script src=powerSpectrumPlot.js></script> -->
     <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
     <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
@@ -110,6 +111,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
     <p id=capacityBanner style="display: none;">
     </p>
 
+    <p><label for="mode">Select mode:</label> &nbsp;
+      <select id="mode" onchange="onModeChange()">
+        <option value="m0">Beginner</option>
+        <option value="m1">Advanced</option>
+      </select>
+    </p>
+
     <div style="display: inline-flex; width: 100%;">
       <div style="width: 25%;">
         <div style="font-size: 110%; color: #ff6b6b">Comm Link 1</div>
@@ -117,13 +125,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
           <input type="range" id=freq1 />
         </p>
         <p>
-          <input type="range" id=bw1 />
+          <input type="range" id=bw1 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn1 />
+          <input type="range" id=gn1 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs1 />
+          <input type="range" id=mcs1 style="display: none;" />
         </p>
       </div>
 
@@ -133,13 +141,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
           <input type="range" id=freq2 />
         </p>
         <p>
-          <input type="range" id=bw2 />
+          <input type="range" id=bw2 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn2 />
+          <input type="range" id=gn2 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs2 />
+          <input type="range" id=mcs2 style="display: none;" />
         </p>
       </div>
 
@@ -149,13 +157,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
           <input type="range" id=freq3 />
         </p>
         <p>
-          <input type="range" id=bw3 />
+          <input type="range" id=bw3 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn3 />
+          <input type="range" id=gn3 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs3 />
+          <input type="range" id=mcs3 style="display: none;" />
         </p>
       </div>
 
@@ -165,13 +173,13 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
           <input type="range" id=freq4 />
         </p>
         <p>
-          <input type="range" id=bw4 />
+          <input type="range" id=bw4 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=gn4 />
+          <input type="range" id=gn4 style="display: none;" />
         </p>
         <p>
-          <input type="range" id=mcs4 />
+          <input type="range" id=mcs4 style="display: none;" />
         </p>
       </div>
     </div>
@@ -293,7 +301,7 @@ Slider(sig4, 'gn', '#gn4');
 Slider(sig4, 'mcs', '#mcs4');
 
 
-// var noise = Signal(conf.noise, "Noise", { gn_init: -40})
+var noise = Signal(conf.noise, "Noise", { gn_init: -40})
 
 new ScriptController([ sig1, sig2, sig3, sig4 ], { 
     element: '#scriptController',

--- a/23_rf_front_end_spectrum_sharing_sliders_programmable.html
+++ b/23_rf_front_end_spectrum_sharing_sliders_programmable.html
@@ -33,6 +33,7 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
     <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
     <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
     <script src=spectralEfficiencyPlot_BarChart.js></script>
+    <script src=sinrPlot_BarChart.js></script>
     <script src=label.js></script>
     <script src=capacityBanner.js></script>
     <!-- <script src=throughputPlot.js></script> -->
@@ -215,11 +216,21 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
     </div>
   </div>
 
-  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%;"></div>
+  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%; margin-top: 1.5%;"></div>
 
-  <div style="width: 720px; height: 320px; display: inline-block;">
-      <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+
+  <div style="display: inline-block; margin-left: 1%;" id="throughput-multisignal">
+    <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
   </div>
+
+<div style="display: inline-flex;">
+  <div style="width: 720px; height: 320px; margin-top: 1%;">
+    <canvas id="sinr-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+  </div>
+
+  <div style="width: 720px; height: 320px; margin-top: 1%; float: right; margin-left: 1%;">
+    <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+</div>
   
   
 </body>
@@ -344,14 +355,16 @@ new ScriptController([ sig1, sig2, sig3, sig4 ], {
 // HoppingInterferer(interferer, '#hoppingInterferer');
 CapacityBanner(sig1, '#capacityBanner');
 
-PowerSpectrumPlot_2D();
 ThroughputPlot([sig1, sig2, sig3, sig4]);
+PowerSpectrumPlot_2D();
 
-// document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
-//       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
-//   </div>`
+  // document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
+  //       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
+  //   </div>`
 
+SinrPlot_BarChart.init([sig1, sig2, sig3, sig4], "sinr-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4"]);
 
 SpectralEfficiencyPlot_BarChart.init([sig1, sig2, sig3, sig4], "spectral-efficiency-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4", "Average Total"]);
+
 </script>
 </html>

--- a/23_rf_front_end_spectrum_sharing_sliders_programmable.html
+++ b/23_rf_front_end_spectrum_sharing_sliders_programmable.html
@@ -113,8 +113,8 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
 
     <p><label for="mode">Select mode:</label> &nbsp;
       <select id="mode" onchange="onModeChange()">
-        <option value="m0">Beginner</option>
-        <option value="m1">Advanced</option>
+        <option id="beginner" value="beginner">Beginner</option>
+        <option id="advanced" value="advanced">Advanced</option>
       </select>
     </p>
 
@@ -225,6 +225,19 @@ Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent
 </body>
 <script>
 'use strict';
+
+// function to listen to url changes
+window.onload = function () {
+    const urlParams = new URLSearchParams(location.search);
+
+    for (const [key, value] of urlParams) {
+      let val = value.toLowerCase();
+      if (key == 'mode' && ['beginner', 'advanced'].includes(val)) {
+        document.getElementById(val).selected = "selected";
+        onModeChange();
+      }
+    }
+};
 
 
 var sig1 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {

--- a/23_rf_front_end_spectrum_sharing_sliders_programmable.html
+++ b/23_rf_front_end_spectrum_sharing_sliders_programmable.html
@@ -90,7 +90,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 23</span> RF Front End - Spectrum Sharing - Both Manual and Automatic Frequency Assignment</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 23</span> RF Front End - Spectrum Sharing - Both Manual and Automatic Frequency Assignment (To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/23_rf_front_end_spectrum_sharing_sliders_programmable.html
+++ b/23_rf_front_end_spectrum_sharing_sliders_programmable.html
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
-<html lang="en-US" style="display: flex;">
+<!--
+To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu 
+with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for 
+Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR
+-->
+ <html lang="en-US" style="display: flex;">
 <head>
     <title>HLSI Ex 23</title>
     <meta charset="UTF-8"/>
@@ -90,7 +95,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 23</span> RF Front End - Spectrum Sharing - Both Manual and Automatic Frequency Assignment (To Do: Fix callback functions; Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 23</span> Spectrum Sharing -- Manual and Programmable</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/24_pathloss.html
+++ b/24_pathloss.html
@@ -1,5 +1,9 @@
 <!DOCTYPE html>
-<html lang="en-US" style="display: flex;">
+<!--
+To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; 
+Replace text-based status display with bar graph that includes text labels, and numeric values
+ -->
+ <html lang="en-US" style="display: flex;">
 <head>
   <title>24 - Path Loss</title>
   <meta charset="UTF-8"/>
@@ -54,7 +58,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 24</span> Path Loss and Interference (Two Comm Links) (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text-based status display with bar graph that includes text labels, and numeric values)</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 24</span> Path Loss and Interference (Two Comm Links)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/24_pathloss.html
+++ b/24_pathloss.html
@@ -54,7 +54,7 @@
       
     </aside>
     
-    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 24</span> Path Loss</div>
+    <div style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;"><span style="color: #ddd;">Exercise 24</span> Path Loss and Interference (Two Comm Links) (To Do: Update spectrum plot to use Lance's framework; Add path loss model menu with 2-3 models; Replace text-based status display with bar graph that includes text labels, and numeric values)</div>
     <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
       <span style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
       <div style="width: 20%;">

--- a/25_rf_front_end_spectrum_sharing_menu.html
+++ b/25_rf_front_end_spectrum_sharing_menu.html
@@ -113,8 +113,8 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
 
     <p><label for="mode">Select mode:</label> &nbsp;
       <select id="mode" onchange="onModeChange()">
-        <option value="m0">Beginner</option>
-        <option value="m1">Advanced</option>
+        <option id="beginner" value="beginner">Beginner</option>
+        <option id="advanced" value="advanced">Advanced</option>
       </select>
     </p>
 
@@ -123,10 +123,10 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
         <label for="strategy">Select SINR calculation option:</label> &nbsp;
         <select id="strategy" onchange="onCategoryChange()">
           <option id="default" value="" selected disabled hidden>Select SINR calculation option...</option>
-          <option value="a0">Ideal filters</option>
-          <option id="ideal1" value="a1" disabled>Ideal filters - equal excess bandwidth</option>
-          <option id="ideal2" value="a2" disabled>Ideal filters - unequal excess bandwidth</option>
-          <option value="a3">Non-ideal filters</option>
+          <option value="a0">Ideal filter with bandwidth equal to signal bandwidth</option>
+          <option id="ideal1" value="a1" disabled>Ideal filter - equal excess bandwidth</option>
+          <option id="ideal2" value="a2" disabled>Ideal filter - unequal excess bandwidth</option>
+          <option value="a3">Non-ideal filter</option>
           <option value="a4">Nonlinear front end</option>
         </select>
       </div>
@@ -360,12 +360,24 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
   // HoppingInterferer(interferer, '#hoppingInterferer');
   CapacityBanner(sig1, '#capacityBanner');
 
+  // function to listen to url changes
+  window.onload = function () {
+    const urlParams = new URLSearchParams(location.search);
+
+    for (const [key, value] of urlParams) {
+      let val = value.toLowerCase();
+      if (key == 'mode' && ['beginner', 'advanced'].includes(val)) {
+        document.getElementById(val).selected = "selected";
+        onModeChange();
+      }
+    }
+  };
 
   function onModeChange() {
     let mode = document.getElementById("mode").value;
 
     // beginner mode
-    if (mode === 'm0') {
+    if (mode === 'beginner') {
       document.getElementById("ideal1").disabled = true;
       document.getElementById("ideal2").disabled = true;
       document.getElementById("multiplierDiv").style.display = "none";
@@ -395,7 +407,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
 
       calculateSINR();
 
-    } else if (mode === 'm1') {
+    } else if (mode === 'advanced') {
       document.getElementById("ideal1").disabled = false;
       document.getElementById("ideal2").disabled = false;
 
@@ -457,10 +469,10 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
 
     // ideal receiver filter with wider bandwidth than the received signal
     if (selection == 'a0') {
-      sig1.bandwidthMultiplier = 1.1;
-      sig2.bandwidthMultiplier = 1.2;
-      sig3.bandwidthMultiplier = 1.3;
-      sig4.bandwidthMultiplier = 1.4;
+      sig1.bandwidthMultiplier = 1;
+      sig2.bandwidthMultiplier = 1;
+      sig3.bandwidthMultiplier = 1;
+      sig4.bandwidthMultiplier = 1;
     }
 
     // ideal receiver filter with equal bandwidth multiplier for all signals

--- a/25_rf_front_end_spectrum_sharing_menu.html
+++ b/25_rf_front_end_spectrum_sharing_menu.html
@@ -281,23 +281,23 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     </div>
   </div>
 
-  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%;"></div>
+  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%; margin-top: 1.5%;"></div>
 
-  <div style="width: 720px; height: 320px; display: inline-block;">
-    <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+
+  <div style="display: inline-block; margin-left: 1%;" id="throughput-multisignal">
+    <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
   </div>
 
-  <div style="margin-left:2%;">
-    <div style="display: inline-flex;">
-      <div style="width: 28px; height: 3px; background:rgba(255,255,255,255); margin-top: 8px; margin-right: 5px;">
-      </div>
-      <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
-    </div>
-  </div>
-
-  <div style="width: 720px; height: 320px; display: inline-block;">
+<div style="display: inline-flex;">
+  <div style="width: 720px; height: 320px; margin-top: 1%;">
     <canvas id="sinr-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
   </div>
+
+  <div style="width: 720px; height: 320px; margin-top: 1%; float: right; margin-left: 1%;">
+    <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+  </div>
+</div>
+ 
 </body>
 <script>
   'use strict';
@@ -598,18 +598,18 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
 
   }
 
-
-  PowerSpectrumPlot_2D();
   ThroughputPlot([sig1, sig2, sig3, sig4]);
+  PowerSpectrumPlot_2D();
 
   // document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
   //       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
   //   </div>`
 
+  SinrPlot_BarChart.init([sig1, sig2, sig3, sig4], "sinr-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4"]);
 
   SpectralEfficiencyPlot_BarChart.init([sig1, sig2, sig3, sig4], "spectral-efficiency-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4", "Average Total"]);
 
-  SinrPlot_BarChart.init([sig1, sig2, sig3, sig4], "sinr-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4"]);
+  
 </script>
 
 </html>

--- a/25_rf_front_end_spectrum_sharing_menu.html
+++ b/25_rf_front_end_spectrum_sharing_menu.html
@@ -155,7 +155,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
         <div class="iip3Div" style="margin-top: 1rem; margin-left: 1rem; display: none;">
           <label for="strategy">IIP3</label> &nbsp;
           <input style="width: 3.5rem;" id="iip3_1" type="text" value="0" oninput="this.value = this.value
-          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[-]*[0-9]+[.]*[0-9]*[-]/, '0');" />
         </div>
         <p>
           <input type="range" id=freq1 />
@@ -181,7 +181,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
         <div class="iip3Div" style="margin-top: 1rem; margin-left: 1rem; display: none;">
           <label for="strategy">IIP3</label> &nbsp;
           <input style="width: 3.5rem;" id="iip3_2" type="text" value="0" oninput="this.value = this.value
-          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[-]*[0-9]+[.]*[0-9]*[-]/, '0');" />
         </div>
         <p>
           <input type="range" id=freq2 />
@@ -207,7 +207,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
         <div class="iip3Div" style="margin-top: 1rem; margin-left: 1rem; display: none;">
           <label for="strategy">IIP3</label> &nbsp;
           <input style="width: 3.5rem;" id="iip3_3" type="text" value="0" oninput="this.value = this.value
-          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[-]*[0-9]+[.]*[0-9]*[-]/, '0');" />
         </div>
         <p>
           <input type="range" id=freq3 />
@@ -233,7 +233,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
         <div class="iip3Div" style="margin-top: 1rem; margin-left: 1rem; display: none;">
           <label for="strategy">IIP3</label> &nbsp;
           <input style="width: 3.5rem;" id="iip3_4" type="text" value="0" oninput="this.value = this.value
-          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[-]*[0-9]+[.]*[0-9]*[-]/, '0');" />
         </div>
         <p>
           <input type="range" id=freq4 />

--- a/25_rf_front_end_spectrum_sharing_menu.html
+++ b/25_rf_front_end_spectrum_sharing_menu.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<!--
+To Do: Add Guard Bands w/ flashing "too-close" indicator, Guard Band menu with options 
+for fixed, receiver-dependent, e.g., lower minimum for Links 1, 2, and 4, higher for Link 3; 
+Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-based SINR
+-->
+<html lang="en-US" style="display: flex;">
+
+<head>
+  <title>HLSI Ex 25</title>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" type="text/css" media="all" href="hlsi.css">
+  <link rel=stylesheet type=text/css href=sidebar.css />
+  <style>
+    output {
+      font-weight: bold;
+    }
+  </style>
+  <script src=d3.v5.min.js></script>
+  <script src=fft.js></script>
+  <script src=common.js></script>
+  <script src=signal.js></script>
+  <!-- <script src=sliders.js></script> -->
+  <script src=slidersMultiSignals.js></script>
+  <!-- <script src=powerSpectrumPlot.js></script> -->
+  <script src=powerSpectrumPlot_2D_MultiSignals.js></script>
+  <script src=powerSpectrumPlot_3D_MultiSignals.js></script>
+  <script src=spectralEfficiencyPlot_BarChart.js></script>
+  <script src=sinrPlot_BarChart.js></script>
+  <script src=label.js></script>
+  <script src=capacityBanner.js></script>
+  <!-- <script src=throughputPlot.js></script> -->
+  <script src=throughputPlotMultiSignals.js></script>
+  <script src=hoppingInterferer.js></script>
+  <script src="https://unpkg.com/d3-simple-slider"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.7.1/chart.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
+
+  <style>
+    input.slider_bw {
+      width: auto;
+    }
+  </style>
+</head>
+
+
+<body style="margin:0;">
+  <section class="banner" style="position: fixed; z-index: 11; background: rgba(0,0,0,0.85)">
+    <label for="menu-control" class="hamburger">
+      <i class="hamburger__icon"></i>
+      <i class="hamburger__icon"></i>
+      <i class="hamburger__icon"></i>
+    </label>
+
+    <input type="checkbox" id="menu-control" class="menu-control">
+
+    <aside class="sidebar" style="z-index: 10;">
+
+      <nav class="sidebar__menu">
+        <a href="01_bw.html"><b>1</b> Bandwidth</a>
+        <a href="02_freq.html"><b>2</b> Frequency</a>
+        <a href="03_gn.html"><b>3</b> Gain</a>
+        <a href="04_freq_bw_gn.html"><b>4</b> Frequency, Bandwidth, and Gain</a>
+        <a href="05_capacity.html"><b>5</b> Information Capacity</a>
+        <a href="06_interference.html"><b>6</b> Interference and Information Capacity</a>
+        <a href="07_capacity.html"><b>7</b> Information Capacity</a>
+        <a href="08_capacity.html"><b>8</b> Information Capacity</a>
+        <a href="09_capacity.html"><b>9</b> Information Capacity</a>
+        <a href="10_capacity.html"><b>10</b> Information Capacity</a>
+        <a href="11_pathloss.html"><b>11</b> Path Loss</a>
+        <a href="12_pathloss_interference.html"><b>12</b> Path Loss with Interference</a>
+        <a href="13_manual_avoidance.html"><b>13</b> Manual Interferer Avoidance</a>
+        <a href="" onclick="alert('Exercise 14: reserved for future use')"><b>14</b> SAS (Spectrum Access System)</a>
+        <a href="15_rule_based_avoidance.html"><b>15</b> Rule Based Interferer Avoidance</a>
+        <a href="16_programmable_avoidance.html"><b>16</b> Programmable Interferer Avoidance</a>
+        <a href="17_machine_learning_avoidance.html"><b>17</b> Machine Learning Interferer Avoidance</a>
+        <a href="18_machine_learning_time_based_avoidance.html"><b>18</b> Machine Learning With Periodic Interferer
+          Avoidance</a>
+        <a href="19_rf_front_end_spectrum_sharing.html" class="selected"><b>19</b> RF Front End Spectrum Sharing</a>
+        <a href="20_rf_front_end_spectrum_sharing.html"><b>20</b> Programmable RF Front End Spectrum Sharing</a>
+        <a href="21_rf_front_end_spectrum_sharing_with_interferer.html"><b>21</b> RF Front End Spectrum Sharing with
+          Interferer</a>
+        <a href="22_rf_front_end_spectrum_sharing_with_interferer.html"><b>22</b> Programmable Spectrum Sharing with
+          Interferer</a>
+        <a href="23_rf_front_end_spectrum_sharing_sliders_programmable.html"><b>23</b> RFFE Spectrum Sharing - Manual
+          and Programmable</a>
+      </nav>
+
+      <label for="menu-control" class="sidebar__close"></label>
+
+
+    </aside>
+
+    <div
+      style="margin-left: 6%; font-size: 1.3rem; margin-top: 0.3%; font-family: sans-serif; order: 1; width: inherit;">
+      <span style="color: #ddd;">Exercise 25</span> Spectrum Sharing -- SINR Calculations Menu
+    </div>
+    <div style="order: 2; margin-left: auto; margin-right: 2%; display: flex;">
+      <span
+        style="font-size: 250%; font-family: monospace; letter-spacing: 2px; margin-left: auto; margin-right: 5px; color: #e6d9ba;"></span>
+      <div style="width: 20%;">
+        <img style="width: 100%;" src="images/wireless-logo.png">
+      </div>
+    </div>
+  </section>
+
+  <div class="content-section" style="margin: 0% 2%; margin-top: 6%;">
+    <!-- <p id=hoppingInterferer>
+    </p> -->
+
+    <p id=capacityBanner style="display: none;">
+    </p>
+
+    <p><label for="mode">Select mode:</label> &nbsp;
+      <select id="mode" onchange="onModeChange()">
+        <option value="m0">Beginner</option>
+        <option value="m1">Advanced</option>
+      </select>
+    </p>
+
+    <div style="padding-bottom: 0.5rem">
+      <div style="display: inline-block;">
+        <label for="strategy">Select SINR calculation option:</label> &nbsp;
+        <select id="strategy" onchange="onCategoryChange()">
+          <option id="default" value="" selected disabled hidden>Select SINR calculation option...</option>
+          <option value="a0">Ideal filters</option>
+          <option id="ideal1" value="a1" disabled>Ideal filters - equal excess bandwidth</option>
+          <option id="ideal2" value="a2" disabled>Ideal filters - unequal excess bandwidth</option>
+          <option value="a3">Non-ideal filters</option>
+          <option value="a4">Nonlinear front end</option>
+        </select>
+      </div>
+
+      <div id="multiplierDiv" style="display: none;">
+        <label style="margin-left: 2rem;" for="strategy">Bandwidth multiplier:</label> &nbsp;
+        <input style="width: 5rem;" id="multiplier" type="text" oninput="this.value = this.value
+        .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+      </div>
+
+      <div style="display: inline-block; margin-left: 2rem;">
+        <input id="apply" type="button" value="Apply Selection" onclick="calculateSINR()">
+      </div>
+    </div>
+
+    <div style="display: inline-flex; width: 100%;">
+      <div style="width: 25%;">
+        <div style="font-size: 110%; color: #ff6b6b">Comm Link 1</div>
+        <div class="bwMultiplierDiv" style="margin-top: 1rem; display: none;">
+          <label for="strategy">Bandwidth multiplier</label> &nbsp;
+          <input style="width: 5rem;" id="multiplier1" type="text" oninput="this.value = this.value
+          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+        </div>
+        <p>
+          <input type="range" id=freq1 />
+        </p>
+        <p>
+          <input type="range" id=bw1 style="display: none;" />
+        </p>
+        <p>
+          <input type="range" id=gn1 style="display: none;" />
+        </p>
+        <p>
+          <input type="range" id=mcs1 style="display: none;" />
+        </p>
+      </div>
+
+      <div style="width: 25%;">
+        <div style="font-size: 110%; color: #b5ebff">Comm Link 2</div>
+        <div class="bwMultiplierDiv" style="margin-top: 1rem; display: none;">
+          <label for="strategy">Bandwidth multiplier</label> &nbsp;
+          <input style="width: 5rem;" id="multiplier2" type="text" oninput="this.value = this.value
+          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+        </div>
+        <p>
+          <input type="range" id=freq2 />
+        </p>
+        <p>
+          <input type="range" id=bw2 style="display: none;" />
+        </p>
+        <p>
+          <input type="range" id=gn2 style="display: none;" />
+        </p>
+        <p>
+          <input type="range" id=mcs2 style="display: none;" />
+        </p>
+      </div>
+
+      <div style="width: 25%;">
+        <div style="font-size: 110%; color: #afffd3">Comm Link 3</div>
+        <div class="bwMultiplierDiv" style="margin-top: 1rem; display: none;">
+          <label for="strategy">Bandwidth multiplier</label> &nbsp;
+          <input style="width: 5rem;" id="multiplier3" type="text" oninput="this.value = this.value
+          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+        </div>
+        <p>
+          <input type="range" id=freq3 />
+        </p>
+        <p>
+          <input type="range" id=bw3 style="display: none;" />
+        </p>
+        <p>
+          <input type="range" id=gn3 style="display: none;" />
+        </p>
+        <p>
+          <input type="range" id=mcs3 style="display: none;" />
+        </p>
+      </div>
+
+      <div style="width: 25%;">
+        <div style="font-size: 110%; color: #ffe699">Comm Link 4</div>
+        <div class="bwMultiplierDiv" style="margin-top: 1rem; display: none;">
+          <label for="strategy">Bandwidth multiplier</label> &nbsp;
+          <input style="width: 5rem;" id="multiplier4" type="text" oninput="this.value = this.value
+          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+        </div>
+        <p>
+          <input type="range" id=freq4 />
+        </p>
+        <p>
+          <input type="range" id=bw4 style="display: none;" />
+        </p>
+        <p>
+          <input type="range" id=gn4 style="display: none;" />
+        </p>
+        <p>
+          <input type="range" id=mcs4 style="display: none;" />
+        </p>
+      </div>
+    </div>
+
+
+    <div style="display:inline-flex;">
+      <span style="font-size: 24px; margin-right: 8px;">3D</span>
+      <label class="switch">
+        <input id="psd_3d_checkbox" type="checkbox" onclick="power_spectral_density_3d_checkbox_change();">
+        <span class="slider round"></span>
+      </label>
+    </div>
+    <div style="width: 30%; display:inline-flex; margin-left:1%;">
+      <div style="display: inline-flex;">
+        <div style="width: 28px; height: 15px; background:rgba(163,36,36,255)"></div>
+        <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Comm Link 1</div>
+      </div>
+
+      <div style="display: inline-flex; margin-left: 10px;">
+        <div style="width: 28px; height: 15px; background:rgba(0,176,240,255);"></div>
+        <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Comm Link 2</div>
+      </div>
+
+      <div style="display: inline-flex; margin-left: 10px;">
+        <div style="width: 28px; height: 15px; background:rgba(36,124,76,255);"></div>
+        <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Comm Link 3</div>
+      </div>
+
+      <div style="display: inline-flex; margin-left: 10px;">
+        <div style="width: 28px; height: 15px; background:rgba(255,192,0,255);"></div>
+        <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Comm Link 4</div>
+      </div>
+    </div>
+  </div>
+
+  <div id="psd_svg_figure_parent" style="float: left; margin-left: 1%;"></div>
+
+  <div style="width: 720px; height: 320px; display: inline-block;">
+    <canvas id="spectral-efficiency-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+  </div>
+
+  <div style="margin-left:2%;">
+    <div style="display: inline-flex;">
+      <div style="width: 28px; height: 3px; background:rgba(255,255,255,255); margin-top: 8px; margin-right: 5px;">
+      </div>
+      <div style="margin-left: 5px; overflow: hidden; white-space: nowrap;">Total Data Throughput</div>
+    </div>
+  </div>
+
+  <div style="width: 720px; height: 320px; display: inline-block;">
+    <canvas id="sinr-bar-chart" style="width: 100%; height: 100%; margin-top:-25px;"></canvas>
+  </div>
+</body>
+<script>
+  'use strict';
+
+
+  var sig1 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {
+    bw_max: 38.0e6, // Hz
+    bw_min: 4.0e6,  // Hz
+    bw_init: 4.0e6, // Hz
+    gn_init: -10, // dB
+    gn_min: -40, // dB
+    mcs_init: 6, // array index int
+    freq_init: 1785.0e6
+  });
+
+  var sig2 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {
+    bw_max: 38.0e6, // Hz
+    bw_min: 4.0e6,  // Hz
+    bw_init: 4.0e6, // Hz
+    gn_init: -10, // dB
+    gn_min: -40, // dB
+    mcs_init: 6, // array index int
+    freq_init: 1795.0e6
+  });
+
+  var sig3 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {
+    bw_max: 38.0e6, // Hz
+    bw_min: 4.0e6,  // Hz
+    bw_init: 4.0e6, // Hz
+    gn_init: -10, // dB
+    gn_min: -40, // dB
+    mcs_init: 6, // array index int
+    freq_init: 1805.0e6
+  });
+
+  var sig4 = Signal(JSON.parse(JSON.stringify(conf.signal_multi)), '', {
+    bw_max: 38.0e6, // Hz
+    bw_min: 4.0e6,  // Hz
+    bw_init: 4.0e6, // Hz
+    gn_init: -10, // dB
+    gn_min: -40, // dB
+    mcs_init: 6, // array index int
+    freq_init: 1815.0e6
+  });
+
+  // sig1['name'] = "comm_link_1";
+  // sig2['name'] = "comm_link_2";
+  // sig3['name'] = "comm_link_3";
+  // sig4['name'] = "comm_link_4";
+
+  // var interferer = new Signal(conf.sig0, 'interferer', {
+  //     bw_max: 38.0e6, // Hz
+  //     bw_init: 2.5e6, // Hz
+  //     gn_init: -12, // dB
+  //     gn_min: -40, // dB
+  //     freq_init: 1785.0e6 // Hz
+  // });
+
+
+  var noise = Signal(conf.noise, "Noise", { gn_init: -40 })
+
+  Slider(sig1, 'freq', '#freq1');
+  Slider(sig1, 'bw', '#bw1');
+  Slider(sig1, 'gn', '#gn1');
+  Slider(sig1, 'mcs', '#mcs1');
+
+  Slider(sig2, 'freq', '#freq2');
+  Slider(sig2, 'bw', '#bw2');
+  Slider(sig2, 'gn', '#gn2');
+  Slider(sig2, 'mcs', '#mcs2');
+
+  Slider(sig3, 'freq', '#freq3');
+  Slider(sig3, 'bw', '#bw3');
+  Slider(sig3, 'gn', '#gn3');
+  Slider(sig3, 'mcs', '#mcs3');
+
+  Slider(sig4, 'freq', '#freq4');
+  Slider(sig4, 'bw', '#bw4');
+  Slider(sig4, 'gn', '#gn4');
+  Slider(sig4, 'mcs', '#mcs4');
+
+  // HoppingInterferer(interferer, '#hoppingInterferer');
+  CapacityBanner(sig1, '#capacityBanner');
+
+
+  function onModeChange() {
+    let mode = document.getElementById("mode").value;
+
+    // beginner mode
+    if (mode === 'm0') {
+      document.getElementById("ideal1").disabled = true;
+      document.getElementById("ideal2").disabled = true;
+      document.getElementById("multiplierDiv").style.display = "none";
+
+      document.getElementById("default").selected = "selected";
+
+      // show only frequeny sliders in beginner mode
+      document.getElementById("bw1").style.display = "none";
+      document.getElementById("gn1").style.display = "none";
+      document.getElementById("mcs1").style.display = "none";
+
+      document.getElementById("bw2").style.display = "none";
+      document.getElementById("gn2").style.display = "none";
+      document.getElementById("mcs2").style.display = "none";
+
+      document.getElementById("bw3").style.display = "none";
+      document.getElementById("gn3").style.display = "none";
+      document.getElementById("mcs3").style.display = "none";
+
+      document.getElementById("bw4").style.display = "none";
+      document.getElementById("gn4").style.display = "none";
+      document.getElementById("mcs4").style.display = "none";
+
+      Array.from(document.getElementsByClassName("bwMultiplierDiv")).forEach(element => {
+        element.style.display = "none";
+      });
+
+      calculateSINR();
+
+    } else if (mode === 'm1') {
+      document.getElementById("ideal1").disabled = false;
+      document.getElementById("ideal2").disabled = false;
+
+      // show only frequeny sliders in beginner mode
+      document.getElementById("bw1").style.display = "initial";
+      document.getElementById("gn1").style.display = "initial";
+      document.getElementById("mcs1").style.display = "initial";
+
+      document.getElementById("bw2").style.display = "initial";
+      document.getElementById("gn2").style.display = "initial";
+      document.getElementById("mcs2").style.display = "initial";
+
+      document.getElementById("bw3").style.display = "initial";
+      document.getElementById("gn3").style.display = "initial";
+      document.getElementById("mcs3").style.display = "initial";
+
+      document.getElementById("bw4").style.display = "initial";
+      document.getElementById("gn4").style.display = "initial";
+      document.getElementById("mcs4").style.display = "initial";
+
+    }
+
+  }
+
+  function onCategoryChange() {
+    let selection = document.getElementById("strategy").value;
+
+    // ideal receiver filter with equal bandwidth multiplier for all signals
+    if (selection == 'a1') {
+      document.getElementById("multiplierDiv").style.display = "inline-block";
+    } else {
+      document.getElementById("multiplierDiv").style.display = "none";
+    }
+
+    // ideal receiver filter with unequal bandwidth multipliers 
+    if (selection == 'a2') {
+      Array.from(document.getElementsByClassName("bwMultiplierDiv")).forEach(element => {
+        element.style.display = "inline-block";
+      });
+    } else {
+      Array.from(document.getElementsByClassName("bwMultiplierDiv")).forEach(element => {
+        element.style.display = "none";
+      });
+    }
+
+  }
+
+  // applies sinr calculation selection and triggers callbacks to calculate SINR
+  function calculateSINR() {
+
+    let selection = document.getElementById("strategy").value;
+
+    if (selection == '') {
+      sig1.bandwidthMultiplier = 1;
+      sig2.bandwidthMultiplier = 1;
+      sig3.bandwidthMultiplier = 1;
+      sig4.bandwidthMultiplier = 1;
+    }
+
+    // ideal receiver filter with wider bandwidth than the received signal
+    if (selection == 'a0') {
+      sig1.bandwidthMultiplier = 1.1;
+      sig2.bandwidthMultiplier = 1.2;
+      sig3.bandwidthMultiplier = 1.3;
+      sig4.bandwidthMultiplier = 1.4;
+    }
+
+    // ideal receiver filter with equal bandwidth multiplier for all signals
+    if (selection == 'a1') {
+      let bwMultiplier = document.getElementById("multiplier").value;
+      if (bwMultiplier && bwMultiplier.length > 0) {
+        let bw_m = Number(bwMultiplier);
+
+        sig1.bandwidthMultiplier = bw_m;
+        sig2.bandwidthMultiplier = bw_m;
+        sig3.bandwidthMultiplier = bw_m;
+        sig4.bandwidthMultiplier = bw_m;
+      } else {
+        return;
+      }
+    }
+
+    // ideal receiver filter with unequal bandwidth multipliers 
+    if (selection == 'a2') {
+      let bwMultiplier1 = document.getElementById("multiplier1").value;
+      let bwMultiplier2 = document.getElementById("multiplier2").value;
+      let bwMultiplier3 = document.getElementById("multiplier3").value;
+      let bwMultiplier4 = document.getElementById("multiplier4").value;
+
+      if (bwMultiplier1 && bwMultiplier2 && bwMultiplier3 && bwMultiplier4 &&
+        bwMultiplier1.length > 0 && bwMultiplier2.length > 0 &&
+        bwMultiplier3.length > 0 && bwMultiplier4.length > 0) {
+
+        sig1.bandwidthMultiplier = Number(bwMultiplier1);
+        sig2.bandwidthMultiplier = Number(bwMultiplier2);
+        sig3.bandwidthMultiplier = Number(bwMultiplier3);
+        sig4.bandwidthMultiplier = Number(bwMultiplier4);
+      } else {
+        return;
+      }
+    }
+
+    // trigger callbacks for all signals - (sinr and rate calculations and update plots)
+    sig1.triggerCallbacks();
+    sig2.triggerCallbacks();
+    sig3.triggerCallbacks();
+    sig4.triggerCallbacks();
+
+  }
+
+
+  PowerSpectrumPlot_2D();
+  ThroughputPlot([sig1, sig2, sig3, sig4]);
+
+  // document.body.innerHTML+= `<div style="width: 720px; height: 320px;">
+  //       <canvas id="spectral-efficiency-bar-chart" style="width: 720px"></canvas>
+  //   </div>`
+
+
+  SpectralEfficiencyPlot_BarChart.init([sig1, sig2, sig3, sig4], "spectral-efficiency-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4", "Average Total"]);
+
+  SinrPlot_BarChart.init([sig1, sig2, sig3, sig4], "sinr-bar-chart", ["Comm Link 1", "Comm Link 2", "Comm Link 3", "Comm Link 4"]);
+</script>
+
+</html>

--- a/25_rf_front_end_spectrum_sharing_menu.html
+++ b/25_rf_front_end_spectrum_sharing_menu.html
@@ -134,15 +134,9 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       </div>
 
       <div id="multiplierDiv" style="display: none;">
-        <label style="margin-left: 2rem;" for="strategy">Bandwidth multiplier:</label> &nbsp;
-        <input style="width: 5rem;" id="multiplier" type="text" oninput="this.value = this.value
-        .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
-      </div>
-
-      <div id="iip3Div" style="display: none;">
-        <label style="margin-left: 2rem;" for="strategy">IIP3 (dBm):</label> &nbsp;
-        <input style="width: 5rem;" id="iip3" type="text" oninput="this.value = this.value
-        .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+        <label style="margin-left: 2rem;" for="strategy">BW mult.:</label> &nbsp;
+        <input style="width: 5rem;" id="multiplier" type="text" value="1" oninput="this.value = this.value
+        .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[0.].*/, '');" />
       </div>
 
       <div style="display: inline-block; margin-left: 2rem;">
@@ -154,9 +148,14 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       <div style="width: 25%;">
         <div style="font-size: 110%; color: #ff6b6b">Comm Link 1</div>
         <div class="bwMultiplierDiv" style="margin-top: 1rem; display: none;">
-          <label for="strategy">Bandwidth multiplier</label> &nbsp;
-          <input style="width: 5rem;" id="multiplier1" type="text" oninput="this.value = this.value
-          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+          <label for="strategy">BW mult.</label> &nbsp;
+          <input style="width: 3.5rem;" id="multiplier1" type="text" value="1" oninput="this.value = this.value
+          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[0.].*/, '');" />
+        </div>
+        <div class="iip3Div" style="margin-top: 1rem; margin-left: 1rem; display: none;">
+          <label for="strategy">IIP3</label> &nbsp;
+          <input style="width: 3.5rem;" id="iip3_1" type="text" value="0" oninput="this.value = this.value
+          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
         </div>
         <p>
           <input type="range" id=freq1 />
@@ -175,9 +174,14 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       <div style="width: 25%;">
         <div style="font-size: 110%; color: #b5ebff">Comm Link 2</div>
         <div class="bwMultiplierDiv" style="margin-top: 1rem; display: none;">
-          <label for="strategy">Bandwidth multiplier</label> &nbsp;
-          <input style="width: 5rem;" id="multiplier2" type="text" oninput="this.value = this.value
-          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+          <label for="strategy">BW mult.</label> &nbsp;
+          <input style="width: 3.5rem;" id="multiplier2" type="text" value="1" oninput="this.value = this.value
+          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[0.].*/, '');" />
+        </div>
+        <div class="iip3Div" style="margin-top: 1rem; margin-left: 1rem; display: none;">
+          <label for="strategy">IIP3</label> &nbsp;
+          <input style="width: 3.5rem;" id="iip3_2" type="text" value="0" oninput="this.value = this.value
+          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
         </div>
         <p>
           <input type="range" id=freq2 />
@@ -196,9 +200,14 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       <div style="width: 25%;">
         <div style="font-size: 110%; color: #afffd3">Comm Link 3</div>
         <div class="bwMultiplierDiv" style="margin-top: 1rem; display: none;">
-          <label for="strategy">Bandwidth multiplier</label> &nbsp;
-          <input style="width: 5rem;" id="multiplier3" type="text" oninput="this.value = this.value
-          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+          <label for="strategy">BW mult.</label> &nbsp;
+          <input style="width: 3.5rem;" id="multiplier3" type="text" value="1" oninput="this.value = this.value
+          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[0.].*/, '');" />
+        </div>
+        <div class="iip3Div" style="margin-top: 1rem; margin-left: 1rem; display: none;">
+          <label for="strategy">IIP3</label> &nbsp;
+          <input style="width: 3.5rem;" id="iip3_3" type="text" value="0" oninput="this.value = this.value
+          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
         </div>
         <p>
           <input type="range" id=freq3 />
@@ -217,9 +226,14 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       <div style="width: 25%;">
         <div style="font-size: 110%; color: #ffe699">Comm Link 4</div>
         <div class="bwMultiplierDiv" style="margin-top: 1rem; display: none;">
-          <label for="strategy">Bandwidth multiplier</label> &nbsp;
-          <input style="width: 5rem;" id="multiplier4" type="text" oninput="this.value = this.value
-          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+          <label for="strategy">BW mult.</label> &nbsp;
+          <input style="width: 3.5rem;" id="multiplier4" type="text" value="1" oninput="this.value = this.value
+          .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0').replace(/^[0.].*/, '');" />
+        </div>
+        <div class="iip3Div" style="margin-top: 1rem; margin-left: 1rem; display: none;">
+          <label for="strategy">IIP3</label> &nbsp;
+          <input style="width: 3.5rem;" id="iip3_4" type="text" value="0" oninput="this.value = this.value
+          .replace(/[^0-9.-]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
         </div>
         <p>
           <input type="range" id=freq4 />
@@ -390,8 +404,6 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       document.getElementById("ideal2").disabled = true;
       document.getElementById("nonlinear").disabled = true;
       document.getElementById("multiplierDiv").style.display = "none";
-      document.getElementById("iip3Div").style.display = "none";
-
       document.getElementById("default").selected = "selected";
 
       // show only frequeny sliders in beginner mode
@@ -412,6 +424,10 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       document.getElementById("mcs4").style.display = "none";
 
       Array.from(document.getElementsByClassName("bwMultiplierDiv")).forEach(element => {
+        element.style.display = "none";
+      });
+
+      Array.from(document.getElementsByClassName("iip3Div")).forEach(element => {
         element.style.display = "none";
       });
 
@@ -447,14 +463,14 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     let selection = document.getElementById("strategy").value;
 
     // ideal receiver filter with equal bandwidth multiplier for all signals
-    if (selection == 'a1' || selection == 'a4') {
+    if (selection == 'a1') {
       document.getElementById("multiplierDiv").style.display = "inline-block";
     } else {
       document.getElementById("multiplierDiv").style.display = "none";
     }
 
     // ideal receiver filter with unequal bandwidth multipliers 
-    if (selection == 'a2') {
+    if (selection == 'a2' || selection == 'a4') {
       Array.from(document.getElementsByClassName("bwMultiplierDiv")).forEach(element => {
         element.style.display = "inline-block";
       });
@@ -466,9 +482,26 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
 
     // nonlinear frontend model
     if (selection == 'a4') {
-      document.getElementById("iip3Div").style.display = "inline-block";
+      Array.from(document.getElementsByClassName("iip3Div")).forEach(element => {
+        element.style.display = "inline-block";
+        sig1.nonlinearModel = true;
+        sig2.nonlinearModel = true;
+        sig3.nonlinearModel = true;
+        sig4.nonlinearModel = true;
+      });
     } else {
-      document.getElementById("iip3Div").style.display = "none";
+      Array.from(document.getElementsByClassName("iip3Div")).forEach(element => {
+        element.style.display = "none";
+      });
+      sig1.nonlinearModel = false;
+      sig2.nonlinearModel = false;
+      sig3.nonlinearModel = false;
+      sig4.nonlinearModel = false;
+
+      sig1.iip3Point = null;
+      sig2.iip3Point = null;
+      sig3.iip3Point = null;
+      sig4.iip3Point = null;
     }
 
   }
@@ -483,6 +516,15 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       sig2.bandwidthMultiplier = 1;
       sig3.bandwidthMultiplier = 1;
       sig4.bandwidthMultiplier = 1;
+
+      sig1.nonlinearModel = false;
+      sig2.nonlinearModel = false;
+      sig3.nonlinearModel = false;
+      sig4.nonlinearModel = false;
+      sig1.iip3Point = null;
+      sig2.iip3Point = null;
+      sig3.iip3Point = null;
+      sig4.iip3Point = null;
     }
 
     // ideal receiver filter with wider bandwidth than the received signal
@@ -509,7 +551,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     }
 
     // ideal receiver filter with unequal bandwidth multipliers 
-    if (selection == 'a2') {
+    if (selection == 'a2' || selection == 'a4') {
       let bwMultiplier1 = document.getElementById("multiplier1").value;
       let bwMultiplier2 = document.getElementById("multiplier2").value;
       let bwMultiplier3 = document.getElementById("multiplier3").value;
@@ -523,6 +565,26 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
         sig2.bandwidthMultiplier = Number(bwMultiplier2);
         sig3.bandwidthMultiplier = Number(bwMultiplier3);
         sig4.bandwidthMultiplier = Number(bwMultiplier4);
+      } else {
+        return;
+      }
+    }
+
+    // nonlinear frontend receiver filter 
+    if (selection == 'a4') {
+      let iip3_1 = document.getElementById("iip3_1").value;
+      let iip3_2 = document.getElementById("iip3_2").value;
+      let iip3_3 = document.getElementById("iip3_3").value;
+      let iip3_4 = document.getElementById("iip3_4").value;
+
+      if (iip3_1 && iip3_2 && iip3_3 && iip3_4 &&
+        iip3_1.length > 0 && iip3_2.length > 0 &&
+        iip3_3.length > 0 && iip3_4.length > 0) {
+
+        sig1.iip3Point = Number(iip3_1);
+        sig2.iip3Point = Number(iip3_2);
+        sig3.iip3Point = Number(iip3_3);
+        sig4.iip3Point = Number(iip3_4);
       } else {
         return;
       }

--- a/25_rf_front_end_spectrum_sharing_menu.html
+++ b/25_rf_front_end_spectrum_sharing_menu.html
@@ -84,6 +84,8 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
           Interferer</a>
         <a href="23_rf_front_end_spectrum_sharing_sliders_programmable.html"><b>23</b> RFFE Spectrum Sharing - Manual
           and Programmable</a>
+        <a href="25_rf_front_end_spectrum_sharing_menu.html"><b>25</b> RFFE Spectrum Sharing - Calculate SINR options menu</a>
+
       </nav>
 
       <label for="menu-control" class="sidebar__close"></label>
@@ -126,14 +128,20 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
           <option value="a0">Ideal filter with bandwidth equal to signal bandwidth</option>
           <option id="ideal1" value="a1" disabled>Ideal filter - equal excess bandwidth</option>
           <option id="ideal2" value="a2" disabled>Ideal filter - unequal excess bandwidth</option>
-          <option value="a3">Non-ideal filter</option>
-          <option value="a4">Nonlinear front end</option>
+          <option value="a3" disabled>Non-ideal filter</option>
+          <option id="nonlinear" value="a4" disabled>Nonlinear front end</option>
         </select>
       </div>
 
       <div id="multiplierDiv" style="display: none;">
         <label style="margin-left: 2rem;" for="strategy">Bandwidth multiplier:</label> &nbsp;
         <input style="width: 5rem;" id="multiplier" type="text" oninput="this.value = this.value
+        .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
+      </div>
+
+      <div id="iip3Div" style="display: none;">
+        <label style="margin-left: 2rem;" for="strategy">IIP3 (dBm):</label> &nbsp;
+        <input style="width: 5rem;" id="iip3" type="text" oninput="this.value = this.value
         .replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1').replace(/^0[^.]/, '0');" />
       </div>
 
@@ -380,7 +388,9 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     if (mode === 'beginner') {
       document.getElementById("ideal1").disabled = true;
       document.getElementById("ideal2").disabled = true;
+      document.getElementById("nonlinear").disabled = true;
       document.getElementById("multiplierDiv").style.display = "none";
+      document.getElementById("iip3Div").style.display = "none";
 
       document.getElementById("default").selected = "selected";
 
@@ -410,6 +420,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     } else if (mode === 'advanced') {
       document.getElementById("ideal1").disabled = false;
       document.getElementById("ideal2").disabled = false;
+      document.getElementById("nonlinear").disabled = false;
 
       // show only frequeny sliders in beginner mode
       document.getElementById("bw1").style.display = "initial";
@@ -436,7 +447,7 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
     let selection = document.getElementById("strategy").value;
 
     // ideal receiver filter with equal bandwidth multiplier for all signals
-    if (selection == 'a1') {
+    if (selection == 'a1' || selection == 'a4') {
       document.getElementById("multiplierDiv").style.display = "inline-block";
     } else {
       document.getElementById("multiplierDiv").style.display = "none";
@@ -451,6 +462,13 @@ Separately, a switch to select ideal SINR w/o ACI vs. receiver-dependent ACI-bas
       Array.from(document.getElementsByClassName("bwMultiplierDiv")).forEach(element => {
         element.style.display = "none";
       });
+    }
+
+    // nonlinear frontend model
+    if (selection == 'a4') {
+      document.getElementById("iip3Div").style.display = "inline-block";
+    } else {
+      document.getElementById("iip3Div").style.display = "none";
     }
 
   }

--- a/README.md
+++ b/README.md
@@ -2,4 +2,3 @@
 
 Web Pages and Interactive Components supporting HLSI curriculum.
 [Live examples](https://vtwireless.github.io/HLSI/) are hosted by `github.io`.
-Testing

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 Web Pages and Interactive Components supporting HLSI curriculum.
 [Live examples](https://vtwireless.github.io/HLSI/) are hosted by `github.io`.
+Testing

--- a/capacityBanner.js
+++ b/capacityBanner.js
@@ -73,7 +73,7 @@ function CapacityBanner(sig, parentElement = null) {
         func: function() {
 
             let r = sig.rate;
-
+           
             if(r <= 0) {
                 rate.className = 'red';
                 return "0 b/s";
@@ -84,6 +84,11 @@ function CapacityBanner(sig, parentElement = null) {
             let [scale,units] = scale_units(r,1.0);
             let percent = 100.0 * r/(sig.bw *
                 Math.log2(1 + Math.pow(10.0, sig.sinr/10.0)));
+
+            if (percent > 100) {
+                rate.className = 'red';
+                return "0 b/s";
+            }
 
             return d3.format(".2f")(r*scale) + " " +
                 units + "b/s (" +

--- a/data_signal_controller_cd.txt
+++ b/data_signal_controller_cd.txt
@@ -1,0 +1,139 @@
+/*
+Primary Author: Allan Guo (Duke University)
+Secondary Authors: Ansh Gwash (Virginia Tech), Lina Nayvelt (Duke), Rhea Saxena (Virginia Tech), Davidson Zhu (Duke)
+Acknowledgements to original developer(s) of this module for developing the original code
+This code is developed for the VT online "Hands-on Learning for Radio Frequency Spectrum Innovation" (HLSI) tutorials
+Exercise 18: https://vtwireless.github.io/HLSI/18_machine_learning_time_based_avoidance.html
+To implement the code, paste into bottom Function Callback code box. 
+This code cannot be used with the default interference control codes in the top Function Callback code box. 
+Corresponding interference control codes for this implementation have been provided for reference.
+*/
+
+num_channels = 8; // User configurable number of channels
+bw_margin = 20000000/num_channels; // Calculates associated bandwidth
+bw_margin = (freq_max2 - freq_min2) / num_channels / 2; // one-half the bandwidth of a channel, in Hz
+start_freq = freq_min2 + bw_margin;   // Defines the eligible range of frequencies; Please Keep Constant
+end_freq = freq_max2 - bw_margin;  // Defines the eligible range of frequencies; Please Keep Constant
+bw_error = 5000000; // Error of bandwidth overflow, derived experimentally
+
+qfunc = globalUserData.qfunc;  // Get qfunction 
+available_freq = makeArr(start_freq, end_freq, num_channels) // Create center frequencies of channels
+
+
+timeForML = globalUserData['timeForML'] // Get current Time
+timeScaleForML = 8; // User configurable time-scale
+currentTimeForML = [Math.round(timeForML % timeScaleForML)]; // figures out which time slot the system is in
+
+currentQfunc = deepCopyFunction(qfunc[currentTimeForML]); // Gets part of qfunction associated with current time slot
+
+
+minimum_epsilon = 0.005; // After this value of epsilon is reached, the algorithm switches from exploration (learning) 
+						 // mode to channel selection mode.
+decaying_constant = 0.99;  // How fast should the exploration decay.
+learning_rate = 0.9; // How fast should we learn
+// At every time step; epsilon = decaying_constant**countNumberOfIterations
+// When epsilon < minimum_epsilon; exploration stops.
+
+ind2 = globalUserData["ind2"] // Get index of current interferer frequency saved by interference controller callback.
+nextFreq2 = available_freq[ind2]; // Current center frequency of interference signal
+
+
+if(init){
+
+ 	epsilon = decaying_constant;
+	countNumberOfIterations = 0
+	checkIfStopped = 1
+	//storeBw1 = bw1;
+    start_channel = 0
+    bwInd = 0
+
+}
+else{
+  
+	if ((epsilon > minimum_epsilon ) ){
+       // This the exploration phase, this snippet randomly selects a starting channel and bandwidth     
+      
+	   start_channel = getRandomInt(num_channels) // Randomly select the lowest frequency channel that will be used.
+       bwInd = getRandomInt(8-start_channel) // Randomly select a signal bandwidth such that the signal uses one, 
+	                                         // some, or all of the channels from start_channel through num-channels.     
+ 	}
+	else{
+	    // If no longer in the exploration phase, use the Q-function to select the best frequency-bandwidth combination.
+	   currentQfunc = deepCopyFunction(qfunc[currentTimeForML]);  // Get Q-function for the current time slot.
+      
+       //Select best channel and bandwidth by looping over currentQfunc
+       start_channel = 0; // Initial channel index
+       bwInd = 0; // Initial data signal bandwidth index
+       best_val = currentQfunc[start_channel][bwInd]; // Q-value for best known combination of start channel and bandwidth
+      
+       for (i = 0; i < num_channels; i++) { // Step through channels
+         for (j = 0; j < num_channels - i; j++) { // Step through bandwidths
+           val = currentQfunc[i][j];  // Q-value for current combination of channel and bandwidth
+           if (val > best_val) {  // Update best_val if the current channel-bandwidth combination has a higher Q-value
+								  // than the previous best channel-bandwidth combination.
+             start_channel = i;
+             bwInd = j;
+             best_val = val;
+           }
+         }
+       }    
+	}
+    //Determines whether to end exploring phase
+	if ((epsilon <= minimum_epsilon ) & (checkIfStopped == 1) ){
+		checkIfStopped = 0
+		alert("Exploring Stopped");
+	}
+	
+    //Updates parameters
+	nextFreq1 = (available_freq[start_channel] + available_freq[start_channel + bwInd])/2;  // Center frequency for available contiguous bandwidth 
+	epsilon = decaying_constant**countNumberOfIterations; //decay epsilon value
+	countNumberOfIterations = countNumberOfIterations +1 // Count Number of iterations
+    freq1 = nextFreq1;  // Next center frequency for data signal = center frequency for available contiguous bandwidth
+    bw1 =  (1 + bwInd)*(40000000/num_channels) - bw_error;  // Next bandwidth for data signal
+    bw1 =  (1 + bwInd)*((freq_max2 - freq_min2) / num_channels) - bw_error;  // Next bandwidth for data signal
+}
+
+// Update Q-values:
+
+//The following section is more "conventional" q-learning.
+//If there is interference, penalize, else reward
+
+if (start_channel <= ind2 && ind2 <= start_channel + bwInd) { // Penalize if interfering signal channel is within the data signal bandwidth.
+  currentQfunc[start_channel][bwInd] = currentQfunc[start_channel][bwInd] +learning_rate*(-1 + currentQfunc[start_channel][bwInd]);
+} else { // Reward if interfering signal channel is not within the data signal bandwidth (e.g., there is no interference).
+         // Greater data signal bandwidth results in a greater reward, so larger bandwidths will be selected if they are likely to be available.
+  currentQfunc[start_channel][bwInd] = currentQfunc[start_channel][bwInd] +learning_rate*(bwInd + currentQfunc[start_channel][bwInd]);
+}
+
+
+// Alternative code to update Q-values:
+
+//The below commented out code updates the qvalues for all states and actions in currentQfunc.
+//In this sense it isn't "conventional" qlearning. However this yields more learning per iteration.
+
+/*
+//Looping over i loops over the start_channels; looping over j loops over bwInd
+for (i = 0; i < ind2 + 1; i++) {
+ //These states do not overlap with the interference, thus reward
+ for (j = 0; j < ind2 - i; j++) {
+  currentQfunc[i][j] = currentQfunc[i][j] +learning_rate*((j/(num_channels - 1))**10 + currentQfunc[i][j]); // Update Q-Value Function 
+ }
+ //These states overlap with the interference, thus penalize
+ for (j = ind2 - i; j < num_channels - i; j++) {
+   currentQfunc[i][j] = currentQfunc[i][j] +learning_rate*(-4 + currentQfunc[i][j])
+ }
+}
+for (i = ind2 + 1; i < num_channels + 1; i++) {
+  //These states don't interfere with the interference
+  for (j = 0; j < num_channels - i; j++) {
+    currentQfunc[i][j] = currentQfunc[i][j] +learning_rate*((j/(num_channels - 1))**10 + currentQfunc[i][j]);
+  }
+}
+*/
+
+
+//Update qfunc
+qfunc[currentTimeForML] = deepCopyFunction(currentQfunc) // Update the Q-function for the current time slot to include the calculated Q-values.
+globalUserData.qfunc = qfunc; // Save the Q-function array for future use.
+
+return {freq1: freq1, bw1:bw1}; // Set the data signal frequency and bandwidth.

--- a/functions/DesiredSignalQFuncTimeSeries.js
+++ b/functions/DesiredSignalQFuncTimeSeries.js
@@ -353,7 +353,7 @@ return {  freq1: freq1 };
 
 
 
-    "Time Aware Q-Function - Contiguous Bandwidth":
+    "Time Aware Q-Function - Two-Channel Contiguous Bandwidth":
 
 function() {
 
@@ -421,7 +421,7 @@ else{
 	
 	if ((epsilon > minimum_epsilon ) ){
 		//available_freq = makeArr(start_freq, end_freq, num_channels)
-		// This the exploration phase, this snippet randomly select a channel
+		// This the exploration phase, this snippet randomly selects a channel
 
 		ind1 = getRandomInt(num_channels)
 		nextFreq1 = available_freq[ind1]	
@@ -463,6 +463,150 @@ else{
 
 		bw1 =  storeBw1 *54.2; 		// Select available contiguous bandwidth 
 
+
+	}
+	if ((epsilon <= minimum_epsilon )  & (checkIfStopped == 1) ){
+		checkIfStopped = 0
+		alert("Exploring Stopped");
+	}
+	
+
+	epsilon = decaying_constant**countNumberOfIterations; //decay epsilon value
+	countNumberOfIterations = countNumberOfIterations +1 // Count Number of iterations
+    freq2 = nextFreq2;
+    freq1 = nextFreq1;
+	
+}
+
+if (ind1slicedQfunc1 == ind2){
+	currentQfunc[ind1slicedQfunc1] = currentQfunc[ind1slicedQfunc1] +learning_rate*(-1 + currentQfunc[ind1slicedQfunc1] ); // Update Q-Value Function
+
+}
+if (ind1slicedQfunc2 == ind2){
+	currentQfunc[ind1slicedQfunc2] = currentQfunc[ind1slicedQfunc2] +learning_rate*(-1 + currentQfunc[ind1slicedQfunc2] ); // Update Q-Value Function
+}
+
+qfunc[currentTimeForML] = deepCopyFunction(currentQfunc)
+globalUserData.qfunc = qfunc;
+
+//console.log(qfunc[3])
+return {  freq1: freq1, bw1:bw1 };
+},
+
+
+    "Time Aware Q-Function - Multi-Channel Contiguous Bandwidth":
+
+function() {
+
+
+bw_margin = globalUserData.bw_margin;  //Defines the bandwidth margin; Please Keep Constant
+start_freq = freq_min2 + bw_margin;   //Defines the eligible range of frequencies; Please Keep Constant
+end_freq = freq_max2 - bw_margin;  //Defines the eligible range of frequencies; Please Keep Constant
+num_channels  = globalUserData.num_channels; // Defines the number of channels; Please keep constant
+qfunc = globalUserData.qfunc;  // Define Qfunction
+available_freq = makeArr(start_freq, end_freq, num_channels) // Create Channels
+
+
+timeForML = globalUserData['timeForML'] // Get current Time
+timeScaleForML = globalUserData['timeScaleForML']; // Get Time scale
+numberOfBestChannelsToUse = 4;
+
+currentTimeForML = [Math.round(timeForML % timeScaleForML)];
+
+	
+
+qfunc = globalUserData.qfunc; 
+currentQfunc = deepCopyFunction(qfunc[currentTimeForML]);
+
+var len = currentQfunc.length;
+var indices = new Array(len);
+for (var i = 0; i < len; ++i) indices[i] = i;
+
+
+minimum_epsilon = 0.25; // This is the cut-off point. After this point, the Algorithm selects the best channels
+// After this value of epsilon is reached, the algorithms switches from exploration (learning) mode to channel selection mode
+decaying_constant = 0.99;  // How fast should the exploration decay.
+learning_rate = 0.9; // How fast should we learn
+// At every time step; epsilon = decaying_constant**countNumberOfIterations
+// When epsilon < minimum_epsilon; exploration stops
+
+
+ 
+
+if(init){
+
+
+
+ 	epsilon  = decaying_constant;
+	countNumberOfIterations = 0
+	available_freq = makeArr(start_freq, end_freq, num_channels)
+	ind1 = 0;
+	ind1slicedQfunc1 = ind1;
+	ind1slicedQfunc2 = ind1;
+
+	ind2 = globalUserData["ind2"]
+	nextFreq2 = available_freq[ind2];
+	var saveIndArr = new Array(num_channels).fill(0);
+
+	checkIfStopped = 1
+	storeBw1 = bw1;
+
+
+}
+else{
+
+	ind2 = globalUserData["ind2"]
+	nextFreq2 = available_freq[ind2];
+	prob_epsilon = Math.random();
+
+	
+	if ((epsilon > minimum_epsilon ) ){
+		//available_freq = makeArr(start_freq, end_freq, num_channels)
+		// This the exploration phase, this snippet randomly selects a channel
+
+		ind1 = getRandomInt(num_channels)
+		nextFreq1 = available_freq[ind1]	
+		ind1slicedQfunc1 = ind1;
+		ind1slicedQfunc2 = ind1;
+
+ 	}
+	else{ // Not in exploration phase
+		currentQfunc = deepCopyFunction(qfunc[currentTimeForML]);
+
+// Begin section to update or replace:  Goal is to find best N adjacent channels
+
+		indices.sort(function (a, b) { return (currentQfunc[a] > currentQfunc[b]) ? -1 : ((currentQfunc[a] < currentQfunc[b]) ? 1 : 0); }); // Sort the Q-values
+		slicedQfunc = indices.slice(0,numberOfBestChannelsToUse)  // Get the best channels
+
+		// Select available contiguous bandwidth 
+		saveInd = slicedQfunc[0];
+		for (var indSliced = 1; indSliced < numberOfBestChannelsToUse; ++indSliced){
+	
+			if (Math.abs(slicedQfunc[indSliced] - saveInd) == 1 ){
+				//console.log("Previous: " + saveInd + " Next: " + indSliced )
+
+				break;
+			}
+			else
+				saveInd = slicedQfunc[indSliced]
+		}
+		len_slicedQfunc = slicedQfunc.length  // Get the number of best channels
+		ind1slicedQfunc = slicedQfunc[getRandomInt(len_slicedQfunc)] // Randomly select a channel from the best channels
+		
+		//ind1slicedQfunc1 = slicedQfunc[saveInd];  		// Select available contiguous bandwidth 
+		//ind1slicedQfunc2 = slicedQfunc[saveInd+1];  		// Select available contiguous bandwidth
+		ind1slicedQfunc1 = saveInd   		// Select available contiguous bandwidth 
+		ind1slicedQfunc2 = saveInd + 1    		// Select available contiguous bandwidth 
+
+		console.log(ind1slicedQfunc1,ind1slicedQfunc2,slicedQfunc)
+
+		nextFreq1_1 = available_freq[ind1slicedQfunc1]	 		// Select available contiguous bandwidth 
+		nextFreq1_2 = available_freq[ind1slicedQfunc2] 		// Select available contiguous bandwidth 
+		nextFreq1 = (nextFreq1_1 + nextFreq1_2)/2; 		// Select available contiguous bandwidth 
+
+		bw1 =  storeBw1 *54.2; 		// Select available contiguous bandwidth 
+
+// End section to update or replace (?)	
 
 	}
 	if ((epsilon <= minimum_epsilon )  & (checkIfStopped == 1) ){

--- a/functions/HoppingInteferenceTimeSeries.js
+++ b/functions/HoppingInteferenceTimeSeries.js
@@ -134,61 +134,36 @@ var functions = {
 
 function() {
 bw_margin = globalUserData.bw_margin;  //Defines the bandwidth margin; Please Keep Constant
-
 start_freq = freq_min2 + bw_margin;   //Defines the eligible range of frequencies; Please Keep Constant
-
 end_freq = freq_max2 - bw_margin;  //Defines the eligible range of frequencies; Please Keep Constant
-
 num_channels  = globalUserData.num_channels; // Defines the number of channels; Please keep constant
-
 available_freq = makeArr(start_freq, end_freq, num_channels) // Create Channels
 
- 
-
 globalUserData['timeForML'] = globalUserData['timeForML'] + 1 // Update Current Time
-
 timeForML = globalUserData['timeForML'] // Get current Time
 
 timeScaleForML = 8 // Set Time scale
-
 globalUserData['timeScaleForML'] = timeScaleForML; // Get Time scale
 
- 
 
-hoppingVector = [0,1,2,3,4,5,6,7]
+hoppingVector = [0,1,2,3,4,5,6,7] // Frequency channels to be occupied during consecutive time slots
 
- 
-
- 
 
 if(init){
-
                qfunc = Array(globalUserData['timeScaleForML']).fill(0).map(x => Array(num_channels).fill(0))
-
                globalUserData['qfunc'] = qfunc;
-
 }
-
  
 
 ind2 = hoppingVector[Math.round(timeForML % timeScaleForML)];
-
 globalUserData["ind2"] = ind2
-
 freq2 = available_freq[ind2];
 
- 
 
 if(freq2 > freq_max2)
-
     freq2 = freq_max2;
-
 else if(freq2 < freq_min2)
-
     freq2 = freq_min2;
-
- 
-
  
 
 return { freq2: freq2, freq1: freq1 };

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
         <li><a href="21_rf_front_end_spectrum_sharing_with_interferer.html">21 - RF Front End Spectrum Sharing with Interferer</a></li>
         <li><a href="22_rf_front_end_spectrum_sharing_with_interferer.html">22 - Programmable Spectrum Sharing with Interferer</a></li>
         <li><a href="23_rf_front_end_spectrum_sharing_sliders_programmable.html"><b>23</b> RFFE Spectrum Sharing - Manual and Programmable</a></li>
+        <li><a href="25_rf_front_end_spectrum_sharing_menu.html"><b>25</b> RFFE Spectrum Sharing - Calculate SINR options menu</a></li>
 
 
         <!-- <li><a href=></a></li> -->

--- a/interference_periodic_cd.txt
+++ b/interference_periodic_cd.txt
@@ -1,0 +1,53 @@
+/*
+Primary Author: Allan Guo (Duke University)
+Secondary Authors: Ansh Gwash (Virginia Tech), Lina Nayvelt (Duke), Rhea Saxena (Virginia Tech), Davidson Zhu (Duke)
+Acknowledgements to original developer(s) of this module for developing the original code
+This code is developed for the VT online "Hands-on Learning for Radio Frequency Spectrum Innovation" (HLSI) tutorials
+Exercise 18: https://vtwireless.github.io/HLSI/18_machine_learning_time_based_avoidance.html
+To implement the code, paste into top Function Callback code box. This code controls a periodic interference signal.
+*/
+
+num_channels = 8; //number of channels considered
+bw_margin = 20000000/num_channels; // one-half the bandwidth of a channel, in Hz
+bw_margin = (freq_max2 - freq_min2) / num_channels / 2; // one-half the bandwidth of a channel, in Hz
+
+start_freq = freq_min2 + bw_margin; //center frequency of lowest channel   
+end_freq = freq_max2 - bw_margin; //center frequency of highest channel
+available_freq = makeArr(start_freq, end_freq, num_channels) //array of center frequencies of channels
+
+globalUserData['timeForML'] = globalUserData['timeForML'] + 1 // Update Current Time
+timeForML = globalUserData['timeForML'] // Get current Time
+timeScaleForML = 8 // Set Time scale (number of time slots in repeating sequence)
+globalUserData['timeScaleForML'] = timeScaleForML; // Save Time scale to globalUserData for future use.
+
+// Hopping vector has size equal to number of channels.
+hoppingVector = [0,1,2,3,4,5,6,7]; // sequence of channels to which the interferer hops during each consecutive 
+								   // set of timeScaleForML time slots.
+
+if(init){
+  //initialization:  Initializing Q-function here for use in Data Signal Controller callback
+               globalUserData['timeForML'] = 0;
+               timeForML = 0;
+               //qfunc here is three dimensional matrix. axis 0 accounts for the timescale, axis 1 accounts for the starting channel in which data signal is 
+               //transmitted through, and axis 2 accounts for bandwidth of transmitted signal
+               //Note that this qfunc is not a conventonal qlearning matrix since it is three-dimensional, but it is straightforward to convert into a 2d one, 
+               //though other parts of code will need to be updated.
+               qfunc = Array(globalUserData['timeScaleForML']).fill(0).map(x => Array(num_channels).fill(0).map(x => Array(num_channels).fill(0)));
+               globalUserData['qfunc'] = qfunc; // Save qfunc to globalUserData for future use.
+}
+
+ind2 = hoppingVector[Math.round(timeForML % timeScaleForML)]; // index of interferer frequency for current time slot
+
+globalUserData["ind2"] = ind2 // Save to globalUserData for future use.
+
+freq2 = available_freq[ind2]; // Get interferer frequency for current time slot.
+
+//Part of original code that forces interferer frequency to be within the displayed bandwidth, commented out
+/*
+if(freq2 > freq_max2)
+    freq2 = freq_max2;
+else if(freq2 < freq_min2)
+    freq2 = freq_min2;
+*/
+ 
+return { freq2: freq2};

--- a/interference_probabilistic_cd.txt
+++ b/interference_probabilistic_cd.txt
@@ -1,0 +1,52 @@
+/*
+Primary Author: Allan Guo (Duke University)
+Secondary Authors: Ansh Gwash (Virginia Tech), Lina Nayvelt (Duke), Rhea Saxena (Virginia Tech), Davidson Zhu (Duke)
+Acknowledgements to original developer(s) of this module for developing the original code
+This code is developed for the VT online "Hands-on Learning for Radio Frequency Spectrum Innovation" (HLSI) tutorials
+Exercise 18: https://vtwireless.github.io/HLSI/18_machine_learning_time_based_avoidance.html
+To implement the code, paste into top Function Callback code box. This code controls a probabilistic interference signal.
+*/
+
+num_channels = 8; //number of channels considered
+bw_margin = 20000000/num_channels; //bandwidth of each channel
+bw_margin = (freq_max2 - freq_min2) / num_channels / 2; // one-half the bandwidth of a channel, in Hz
+
+start_freq = freq_min2 + bw_margin;   //center frequency of lowest channel 
+end_freq = freq_max2 - bw_margin;  //center frequency of highest channel
+available_freq = makeArr(start_freq, end_freq, num_channels) //array of center frequencies of channels
+
+globalUserData['timeForML'] = globalUserData['timeForML'] + 1 // Update Current Time
+timeForML = globalUserData['timeForML'] // Get current Time
+timeScaleForML = 8 // Set Time scale (number of time slots in repeating sequence)
+globalUserData['timeScaleForML'] = timeScaleForML; // Save Time scale to globalUserData for future use.
+
+//hoppingVector must have size equal to the number of channels
+hoppingVector = [1/7, 1/7, 1/7, 1/7, 1/7, 1/7, 1/7, 0]; //vector of probabilities for each channel, sum must add to 1
+
+if(init){
+  // initialization:  Initializing Q-function here for use in Data Signal Controller callback
+    globalUserData['timeForML'] = 0;
+    timeForML = 0;
+    //console.log("initial time " + timeForML);
+    //qfunc here is three dimensional matrix. axis 0 accounts for the timescale, axis 1 accounts for the starting channel in which data signal is 
+    //transmitted through, and axis 2 accounts for bandwidth of transmitted signal
+    //Note that this qfunc is not a conventonal qlearning matrix since it is three-dimensional, but it is straightforward to convert into a 2d one, 
+    //though other parts of code will need to be updated.
+	qfunc = Array(globalUserData['timeScaleForML']).fill(0).map(x => Array(num_channels).fill(0).map(x => Array(num_channels).fill(0)));
+	globalUserData['qfunc'] = qfunc;
+}
+
+ind2 = randomChoice(hoppingVector) //choose interference channel
+globalUserData["ind2"] = ind2 // Save ind2 for future use.
+	
+freq2 = available_freq[ind2];
+
+//Part of original code that forces interferer frequency to be within the displayed bandwidth, commented out
+/*
+if(freq2 > freq_max2)
+    freq2 = freq_max2;
+else if(freq2 < freq_min2)
+    freq2 = freq_min2;
+*/
+
+return { freq2: freq2};

--- a/modeController.js
+++ b/modeController.js
@@ -1,0 +1,49 @@
+// Helper function to control the visibility of the sliders 
+// Beginner mode - show only the frequency sliders
+// Advanced mode - show all the slider
+
+function onModeChange() {
+    let mode = document.getElementById("mode").value;
+
+    // beginner mode
+    if (mode === 'm0') {
+        // show only frequeny sliders in beginner mode
+        document.getElementById("bw1").style.display = "none";
+        document.getElementById("gn1").style.display = "none";
+        document.getElementById("mcs1").style.display = "none";
+
+        document.getElementById("bw2").style.display = "none";
+        document.getElementById("gn2").style.display = "none";
+        document.getElementById("mcs2").style.display = "none";
+
+        document.getElementById("bw3").style.display = "none";
+        document.getElementById("gn3").style.display = "none";
+        document.getElementById("mcs3").style.display = "none";
+
+        document.getElementById("bw4").style.display = "none";
+        document.getElementById("gn4").style.display = "none";
+        document.getElementById("mcs4").style.display = "none";
+
+    } else if (mode === 'm1') {
+
+        // show only frequeny sliders in beginner mode
+        document.getElementById("bw1").style.display = "initial";
+        document.getElementById("gn1").style.display = "initial";
+        document.getElementById("mcs1").style.display = "initial";
+
+        document.getElementById("bw2").style.display = "initial";
+        document.getElementById("gn2").style.display = "initial";
+        document.getElementById("mcs2").style.display = "initial";
+
+        document.getElementById("bw3").style.display = "initial";
+        document.getElementById("gn3").style.display = "initial";
+        document.getElementById("mcs3").style.display = "initial";
+
+        document.getElementById("bw4").style.display = "initial";
+        document.getElementById("gn4").style.display = "initial";
+        document.getElementById("mcs4").style.display = "initial";
+
+    }
+
+}
+

--- a/modeController.js
+++ b/modeController.js
@@ -6,7 +6,7 @@ function onModeChange() {
     let mode = document.getElementById("mode").value;
 
     // beginner mode
-    if (mode === 'm0') {
+    if (mode === 'beginner') {
         // show only frequeny sliders in beginner mode
         document.getElementById("bw1").style.display = "none";
         document.getElementById("gn1").style.display = "none";
@@ -24,7 +24,7 @@ function onModeChange() {
         document.getElementById("gn4").style.display = "none";
         document.getElementById("mcs4").style.display = "none";
 
-    } else if (mode === 'm1') {
+    } else if (mode === 'advanced') {
 
         // show only frequeny sliders in beginner mode
         document.getElementById("bw1").style.display = "initial";

--- a/powerSpectrumPlot_2D_MultiSignals.js
+++ b/powerSpectrumPlot_2D_MultiSignals.js
@@ -236,9 +236,21 @@ function PowerSpectrumPlot_2D(opts = {}, has_signal=true, has_interferer=true) {
 
         sig.signal_label_f = signal_label_f;
 
+        var signal_label_recv_p = svgf
+            .append("text")
+            .attr("clip-path", "url(#clipf)")
+            .attr("x", "200")
+            .attr("y", "150")
+            .attr("fill", color_label)
+            // .attr("id", "signal_label")
+            .text(`Signal (${0.0})`);
+
+        sig.signal_label_recv_p = signal_label_recv_p;
+
         if(sig['name']=='interferer'){
             signal_box_f.attr("fill", interferer_colors_fill).attr("stroke", interferer_colors_stroke);
             signal_label_f.attr("fill", interferer_colors_label)
+            signal_label_recv_p.attr("fill", interferer_colors_label)
             return;
         }
         
@@ -280,8 +292,13 @@ function PowerSpectrumPlot_2D(opts = {}, has_signal=true, has_interferer=true) {
             let signal_label_new_coordinates = get_graph_label_coordinates(720, 320, sig.cur_signal_freq);
             sig.signal_label_f.attr("x", signal_label_new_coordinates['x']+8*sig_i);
             sig.signal_label_f.attr("y", signal_label_new_coordinates['y']-8);
+
+            sig.signal_label_recv_p.attr("x", signal_label_new_coordinates['x']+8*sig_i + 10);
+            sig.signal_label_recv_p.attr("y", signal_label_new_coordinates['y']-8 - 75);
+
             // sig.signal_label_f.text(`Comm Link ${sig_i+1} (${sig.cur_signal_freq_exact}MHz)`);
             sig.signal_label_f.text(`${sig.cur_signal_freq_exact}MHz`);
+            sig.signal_label_recv_p.text(`RP : ${sig.receiverPerformance}`);
 
             sig_i+=1;
         });

--- a/powerSpectrumPlot_2D_MultiSignals.js
+++ b/powerSpectrumPlot_2D_MultiSignals.js
@@ -206,6 +206,11 @@ function PowerSpectrumPlot_2D(opts = {}, has_signal=true, has_interferer=true) {
         let color_stroke = signal_colors_stroke[signal_color_i%signal_colors_stroke.length];
         let color_label = signal_colors_label[signal_color_i%signal_colors_stroke.length];
         let sig = Signal.env[key];
+
+        if (sig.is_noise) {
+            return;
+        }
+        
         var signal_box_f = svgf
         .append("rect")
         .attr("clip-path", "url(#clipf)")
@@ -255,6 +260,7 @@ function PowerSpectrumPlot_2D(opts = {}, has_signal=true, has_interferer=true) {
             
             sig.cur_signal_freq = fc;
             sig.cur_signal_bw = bw;
+            sig.cur_signal_bw_ideal_filter = (sig.bw * sig.bandwidthMultiplier) / df;
             sig.cur_signal_freq_exact = sig._freq;
             
             
@@ -264,7 +270,7 @@ function PowerSpectrumPlot_2D(opts = {}, has_signal=true, has_interferer=true) {
             generator.add_signal(fc, bw, gn + 10 * Math.log10(bw));
             //generator.add_signal(fc, bw, gn);
 
-            let signal_bounding_box_new_coordinates = get_bounding_box_coordinates(750, 320, sig.cur_signal_freq, sig.cur_signal_bw);
+            let signal_bounding_box_new_coordinates = get_bounding_box_coordinates(750, 320, sig.cur_signal_freq, sig.cur_signal_bw_ideal_filter);
             sig.signal_box_f.attr("x", signal_bounding_box_new_coordinates['x']);
             sig.signal_box_f.attr("y", signal_bounding_box_new_coordinates['y']);
             sig.signal_box_f.attr("width", signal_bounding_box_new_coordinates['width']);
@@ -356,7 +362,18 @@ function PowerSpectrumPlot_2D(opts = {}, has_signal=true, has_interferer=true) {
         
         let bw_offset = graph_width*signal_bw;
         let fc_added = 0.5+fc;
-        let new_x = -5 + graph_width*fc_added - (bw_offset/2);
+        let new_x = 0;
+
+        if (fc >= 0 && fc <= 0.125) {
+            new_x = -4 + graph_width*fc_added - (bw_offset/2);
+        } else if (fc >= 0.125) {
+            new_x = -1.5 + graph_width*fc_added - (bw_offset/2);
+        } else if (fc <= 0 && fc >= -0.125) {
+            new_x = -5 + graph_width*fc_added - (bw_offset/2);
+        } else if (fc <= -0.125) {
+            new_x = -8.5 + graph_width*fc_added - (bw_offset/2);
+        }
+
         let new_width = bw_offset+20;
         
         let bounding_box_coordinates = {x:new_x, y:50, width:new_width, height:200};

--- a/powerSpectrumPlot_3D_MultiSignals.js
+++ b/powerSpectrumPlot_3D_MultiSignals.js
@@ -226,6 +226,11 @@ function PowerSpectrumPlot_3D(opts = {}, has_signal=true, has_interferer=true) {
         let color_stroke = signal_colors_stroke[signal_color_i%signal_colors_stroke.length];
         let color_label = signal_colors_label[signal_color_i%signal_colors_stroke.length];
         let sig = Signal.env[key];
+
+        if (sig.is_noise) {
+            return;
+        }
+        
         var signal_box_f = svg
         .append("rect")
         .attr("clip-path", "url(#clipf)")
@@ -274,6 +279,7 @@ function PowerSpectrumPlot_3D(opts = {}, has_signal=true, has_interferer=true) {
 
             sig.cur_signal_freq = fc;
             sig.cur_signal_bw = bw;
+            sig.cur_signal_bw_ideal_filter = (sig.bw * sig.bandwidthMultiplier) / df;
             sig.cur_signal_freq_exact = sig._freq;
 
             //console.log("fc=" + fc + " bw=" + bw + " gn=" + gn);
@@ -281,7 +287,7 @@ function PowerSpectrumPlot_3D(opts = {}, has_signal=true, has_interferer=true) {
             generator.add_signal(fc, bw, gn + 10 * Math.log10(bw));
             //generator.add_signal(fc, bw, gn);
 
-            let signal_bounding_box_new_coordinates = get_bounding_box_coordinates(750, 320, sig.cur_signal_freq, sig.cur_signal_bw);
+            let signal_bounding_box_new_coordinates = get_bounding_box_coordinates(750, 320, sig.cur_signal_freq, sig.cur_signal_bw_ideal_filter);
             sig.signal_box_f.attr("x", signal_bounding_box_new_coordinates['x']);
             sig.signal_box_f.attr("y", signal_bounding_box_new_coordinates['y']);
             sig.signal_box_f.attr("width", signal_bounding_box_new_coordinates['width']);

--- a/signal.js
+++ b/signal.js
@@ -900,7 +900,8 @@ function Signal(sig, name = "", opts = null) {
     // calculates the Receiver Performance Metric based on capacity in ideal and non-ideal filter cases
     obj.calculateReceiverPerformance = function() {
         
-        let idealSinr = obj.bandwidthMultiplier != 1 ? obj.calculateSINR(1, false) : obj._sinr;
+        let idealSinr = (obj.bandwidthMultiplier != 1 || obj.nonlinearModel) ? 
+            obj.calculateSINR(1, false) : obj._sinr;
         
         let idealCapacity = obj._bw * Math.log2(1 + Math.pow(10.0, idealSinr/10.));
         let nonIdealCapacity = obj._bw * Math.log2(1 + Math.pow(10.0, obj._sinr/10.));

--- a/signal.js
+++ b/signal.js
@@ -620,8 +620,8 @@ function Signal(sig, name = "", opts = null) {
             if(!i.is_noise &&
                 (
                     // Do they NOT overlap?
-                    (obj._freq - 0.5 * obj.bandwidthMultiplier * obj._bw) >= (i._freq + 0.5*i._bw) ||
-                    (obj._freq + 0.5 * obj.bandwidthMultiplier * obj._bw) <= (i._freq - 0.5*i._bw)
+                    (obj._freq - 0.5 * obj.bandwidthMultiplier * obj._bw) >= (i._freq + 0.5 * i._bw * i.bandwidthMultiplier) ||
+                    (obj._freq + 0.5 * obj.bandwidthMultiplier * obj._bw) <= (i._freq - 0.5 * i._bw * i.bandwidthMultiplier)
                 ))
                 // This interferer (i) is not currently interfering.  It
                 // does not overlap the signal (obj).
@@ -642,16 +642,16 @@ function Signal(sig, name = "", opts = null) {
                 // bw_max number is a fug.
                 ip += obj.bandwidthMultiplier * obj._bw * PowerSpectralDensity(i._gn)/bw_max;
             } else {
-                let min = i._freq - 0.5 * i._bw;
+                let min = i._freq - 0.5 * (i.bandwidthMultiplier * i._bw);
                 if(min < bmin)
                     min = bmin;
-                let max = i._freq + 0.5 * i._bw;
+                let max = i._freq + 0.5 * (i.bandwidthMultiplier * i._bw);
                 if(max > bmax)
                     max = bmax;
                 // partial overlap for non-noise.
                 let b = max - min;
 
-                ip += b * PowerSpectralDensity(i._gn)/i._bw;
+                ip += b * PowerSpectralDensity(i._gn)/ (i.bandwidthMultiplier * i._bw);
             }
         });
 

--- a/sinrPlot_BarChart.js
+++ b/sinrPlot_BarChart.js
@@ -1,0 +1,151 @@
+'use strict';
+
+
+//
+// sig:
+//
+//   is the signal that we are getting the SINR Plot for
+//
+//
+//
+//
+var schemes = conf.schemes;
+
+const SinrPlot_BarChart = {
+    dataset: [],
+    signal_list: [],
+    sinr_chart: null,
+
+    init: function(signal_list, canvas_id, labels){
+        this.signal_list = signal_list;
+        let data = this.generate_dataset(this.signal_list);
+        this.dataset = data;
+        this.create_chart(canvas_id, labels, data);
+        for(let i=0; i<this.signal_list.length; i++){
+            this.signal_list[i].onChange("freq", this.update_plot);
+            this.signal_list[i].onChange("rate", this.update_plot);
+            this.signal_list[i].onChange("sinr", this.update_plot);
+            this.signal_list[i].onChange("mcs", this.update_plot);
+        }
+    },
+
+    generate_dataset: function(signal_list){
+        let dataset = [];
+        for(let i=0; i<signal_list.length; i++){
+            // add SINR value
+            let sinr = signal_list[i].sinr;
+            dataset.push(sinr);
+        }
+        return dataset;
+    },
+
+    get_total_throughput: function(signal_list){
+      let rate = 0;
+      for(let i=0; i<signal_list.length; i++){
+          rate += signal_list[i].rate;
+      }
+      return rate;
+    },
+
+    create_chart: function(canvas_id, labels, data){
+        this.sinr_chart = new Chart(document.getElementById(canvas_id), {
+            type: 'bar',
+            data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: "SINR (dB)",
+                    backgroundColor: ["rgb(200,56,56)", "rgb(0,176,240)","rgb(36,124,76)","rgb(255,192,0)","#8e5ea2"],
+                    data: data
+                }
+            ]
+            },
+            options: {
+                plugins: {
+                    legend: { display: false },
+                    title: {
+                        display: true,
+                        text: 'SINR',
+                        color: "#fff"
+                    },
+                    datalabels: {
+                      anchor: 'end',
+                      align: 'top',
+                      formatter: Math.round,
+                      font: {
+                        weight: 'bold'
+                      }
+                    }
+                },
+                
+                scales: {
+                    x: {
+                      ticks: {
+                        color: "#fff"
+                      },
+                      grid: {
+                        color: "#666"
+                      },
+                    //   title: {
+                    //     display: true,
+                    //     text: 'Your Title',
+                    //     color: "#fff"
+                    //   }
+                    },
+                    y: {
+                      min: -20.0,
+                      max: 50.0,
+                      ticks: {
+                        display: true,
+                        color: "#fff"
+                      },
+                      grid: {
+                        color: "#666"
+                      },
+                      title: {
+                        display: true,
+                        text: 'dB',
+                        color: "#fff",
+                      }
+                    }
+                  }
+            }
+        });
+    },
+
+    update_plot: function() {
+        let cur_dataset = SinrPlot_BarChart.dataset;
+        let new_dataset = SinrPlot_BarChart.generate_dataset(SinrPlot_BarChart.signal_list);
+        
+        // console.log(new_dataset);
+
+        let max_freq = 0.0;
+        let min_freq = 1000000000000;
+        for(let i=0; i<cur_dataset.length; i++){
+            let cur_value = cur_dataset[i];
+            let new_value = new_dataset[i];
+
+            if (new_value === Infinity) {
+              new_value = SinrPlot_BarChart.sinr_chart.scales.y.max;
+            } else if (new_value === -Infinity) {
+              new_value = SinrPlot_BarChart.sinr_chart.scales.y.min;
+            }
+
+            if(new_value != cur_value){
+              // clip values if they exceed the min or max values (inf or -inf)
+              if (new_value > SinrPlot_BarChart.sinr_chart.scales.y.max) {
+                new_value = SinrPlot_BarChart.sinr_chart.scales.y.max;
+              } 
+
+              if (new_value < SinrPlot_BarChart.sinr_chart.scales.y.min) {
+                new_value = SinrPlot_BarChart.sinr_chart.scales.y.min;
+              } 
+
+              SinrPlot_BarChart.sinr_chart.data.datasets[0].data[i] = new_value;
+            }
+        }
+       
+        SinrPlot_BarChart.sinr_chart.update();
+        SinrPlot_BarChart.dataset = new_dataset;
+    }
+}

--- a/throughputPlotMultiSignals.js
+++ b/throughputPlotMultiSignals.js
@@ -96,11 +96,11 @@ function ThroughputPlot(signals, interferers=[]) {
     // historical rate plot
     //
     
-    var svgr = d3.select("body")
+    var svgr = d3.select("#throughput-multisignal")
         .append("svg")
         .attr("width",  width  + margin.left + margin.right)
         .attr("height", height + margin.top +  margin.bottom)
-        .attr("style", "margin-left:1%; float: left;")
+        .attr("style", "float: right;")
         .append("g")
         .attr("transform", "translate(" +
             margin.left + "," + margin.top + ")");

--- a/throughputPlotMultiSignals.js
+++ b/throughputPlotMultiSignals.js
@@ -100,7 +100,7 @@ function ThroughputPlot(signals, interferers=[]) {
         .append("svg")
         .attr("width",  width  + margin.left + margin.right)
         .attr("height", height + margin.top +  margin.bottom)
-        .attr("style", "margin-left:1%;")
+        .attr("style", "margin-left:1%; float: left;")
         .append("g")
         .attr("transform", "translate(" +
             margin.left + "," + margin.top + ")");


### PR DESCRIPTION
Addressed following issues for Exercise 25 --

SINR calculation options menu #31
Refactor SINR calculation code #32
Add SINR Bar graph #33
Add 2nd SINR model #34
Add menu options for Ideal filters with equal and unequal access bandwidths #35
Add Menu options to support 2 modes - Beginner and Advanced mode #36 
Bug -- center the rectangle around the PSD signal curve #37
Update the rectangle widths on PSD plot per the multiplier bandwidth #38

